### PR TITLE
[CVW-032] 단일 심볼 24시간 변화량 UI구현

### DIFF
--- a/Projects/Data/Repository/Sources/BinanceSingleMarketTickerRepository.swift
+++ b/Projects/Data/Repository/Sources/BinanceSingleMarketTickerRepository.swift
@@ -1,5 +1,5 @@
 //
-//  DefaultSingleMarketTickerRepository.swift
+//  BinanceSingleMarketTickerRepository.swift
 //  Data
 //
 //  Created by choijunios on 4/14/25.
@@ -9,13 +9,13 @@ import DomainInterface
 import DataSource
 import CoreUtil
 
-final class DefaultSingleMarketTickerRepository: SingleMarketTickerRepository {
+final public class BinanceSingleMarketTickerRepository: SingleMarketTickerRepository {
     
     @Injected private var webSocketService: WebSocketService
     
     public init() { }
     
-    func request24hTicker(pairSymbol: String) -> AsyncStream<DomainInterface.Twenty4HourTickerForSymbolVO> {
+    public func request24hTickerChange(pairSymbol: String) -> AsyncStream<DomainInterface.Twenty4HourTickerForSymbolVO> {
         let publisher = webSocketService
             .getMessageStream()
             .filter { (dto: BinanceTickerForSymbolDTO) in

--- a/Projects/Data/Repository/Sources/DefaultSingleMarketTickerRepository.swift
+++ b/Projects/Data/Repository/Sources/DefaultSingleMarketTickerRepository.swift
@@ -1,0 +1,35 @@
+//
+//  DefaultSingleMarketTickerRepository.swift
+//  Data
+//
+//  Created by choijunios on 4/14/25.
+//
+
+import DomainInterface
+import DataSource
+import CoreUtil
+
+final class DefaultSingleMarketTickerRepository: SingleMarketTickerRepository {
+    
+    @Injected private var webSocketService: WebSocketService
+    
+    public init() { }
+    
+    func request24hTicker(pairSymbol: String) -> AsyncStream<DomainInterface.Twenty4HourTickerForSymbolVO> {
+        let publisher = webSocketService
+            .getMessageStream()
+            .filter { (dto: BinanceTickerForSymbolDTO) in
+                dto.symbol.lowercased() == pairSymbol.lowercased()
+            }
+            .map({ $0.toEntity() })
+            return AsyncStream { continuation in
+                let cancellable = publisher
+                    .sink(receiveValue: { entity in
+                        continuation.yield(entity)
+                    })
+                continuation.onTermination = { @Sendable _ in
+                    cancellable.cancel()
+                }
+            }
+    }
+}

--- a/Projects/Data/Repository/Sources/ToEntityExtension/BinanceTickerForSymbolDTO+toEntity.swift
+++ b/Projects/Data/Repository/Sources/ToEntityExtension/BinanceTickerForSymbolDTO+toEntity.swift
@@ -14,14 +14,14 @@ import CoreUtil
 // MARK: Binance API
 
 extension BinanceTickerForSymbolDTO {
-    
     func toEntity() -> Twenty4HourTickerForSymbolVO {
-        
-        return .init(
+        .init(
             pairSymbol: symbol,
-            price: CVNumber(Double(lastPrice) ?? 0.0),
-            totalTradedQuoteAssetVolume: CVNumber(Double(quoteAssetVolume) ?? 0.0),
-            changedPercent: CVNumber(Double(priceChangePercent) ?? 0.0)
+            price: CVNumber(Decimal(string: lastPrice) ?? 0.0),
+            totalTradedQuoteAssetVolume: CVNumber(Decimal(string: quoteAssetVolume) ?? 0.0),
+            changedPercent: CVNumber(Double(priceChangePercent) ?? 0.0),
+            bestBidPrice: CVNumber(Decimal(string: bestBidPrice) ?? 0.0),
+            bestAskPrice: CVNumber(Decimal(string: bestAskPrice) ?? 0.0)
         )
     }
 }

--- a/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
@@ -23,7 +23,7 @@ final public class DefaultCoinDetailPageUseCase: CoinDetailPageUseCase {
 
 // MARK: Orderbook
 public extension DefaultCoinDetailPageUseCase {
-    func connectToOrederbookStream(symbolPair: String) {
+    func connectToOrderbookStream(symbolPair: String) {
         webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@depth"])
     }
     

--- a/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
@@ -14,6 +14,7 @@ import CoreUtil
 final public class DefaultCoinDetailPageUseCase: CoinDetailPageUseCase {
 
     @Injected private var orderbookRepository: OrderbookRepository
+    @Injected private var singleTickerRepository: SingleMarketTickerRepository
     @Injected private var webSocketHelper: WebSocketManagementHelper
     
     public init() { }
@@ -32,5 +33,9 @@ public extension DefaultCoinDetailPageUseCase {
     
     func getChangeInOrderbook(symbolPair: String) -> AsyncStream<OrderbookUpdateVO> {
         orderbookRepository.getUpdate(symbolPair: symbolPair)
+    }
+    
+    func get24hChanges(symbolPair: String) -> AsyncStream<Twenty4HourTickerForSymbolVO> {
+        singleTickerRepository.request24hTicker(pairSymbol: symbolPair)
     }
 }

--- a/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
@@ -23,8 +23,12 @@ final public class DefaultCoinDetailPageUseCase: CoinDetailPageUseCase {
 
 // MARK: Orderbook
 public extension DefaultCoinDetailPageUseCase {
-    func connectToStream(symbolPair: String) {
+    func connectToOrederbookStream(symbolPair: String) {
         webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@depth"])
+    }
+    
+    func connectToTickerChangesStream(symbolPair: String) {
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@ticker"])
     }
     
     func getWholeOrderbookTable(symbolPair: String) async throws -> OrderbookUpdateVO {
@@ -35,7 +39,7 @@ public extension DefaultCoinDetailPageUseCase {
         orderbookRepository.getUpdate(symbolPair: symbolPair)
     }
     
-    func get24hChanges(symbolPair: String) -> AsyncStream<Twenty4HourTickerForSymbolVO> {
-        singleTickerRepository.request24hTicker(pairSymbol: symbolPair)
+    func get24hTickerChange(symbolPair: String) -> AsyncStream<Twenty4HourTickerForSymbolVO> {
+        singleTickerRepository.request24hTickerChange(pairSymbol: symbolPair)
     }
 }

--- a/Projects/Domain/Interface/Entity/Twenty4HourTickerForSymbolVO.swift
+++ b/Projects/Domain/Interface/Entity/Twenty4HourTickerForSymbolVO.swift
@@ -17,12 +17,23 @@ public struct Twenty4HourTickerForSymbolVO {
     public let price: CVNumber
     public let totalTradedQuoteAssetVolume: CVNumber
     public let changedPercent: CVNumber
+    public let bestBidPrice: CVNumber
+    public let bestAskPrice: CVNumber
     
-    public init(pairSymbol: String, price: CVNumber, totalTradedQuoteAssetVolume: CVNumber, changedPercent: CVNumber) {
+    public init(
+        pairSymbol: String,
+        price: CVNumber,
+        totalTradedQuoteAssetVolume: CVNumber,
+        changedPercent: CVNumber,
+        bestBidPrice: CVNumber,
+        bestAskPrice: CVNumber
+    ) {
         self.pairSymbol = pairSymbol
         self.price = price
         self.totalTradedQuoteAssetVolume = totalTradedQuoteAssetVolume
         self.changedPercent = changedPercent
+        self.bestBidPrice = bestBidPrice
+        self.bestAskPrice = bestAskPrice
     }
     
     public mutating func setSymbols(closure: (String) -> (String, String)) {

--- a/Projects/Domain/Interface/Repository/SingleMarketTickerRepository.swift
+++ b/Projects/Domain/Interface/Repository/SingleMarketTickerRepository.swift
@@ -6,5 +6,5 @@
 //
 
 public protocol SingleMarketTickerRepository {
-    func request24hTicker(pairSymbol: String) -> AsyncStream<Twenty4HourTickerForSymbolVO>
+    func request24hTickerChange(pairSymbol: String) -> AsyncStream<Twenty4HourTickerForSymbolVO>
 }

--- a/Projects/Domain/Interface/Repository/SingleMarketTickerRepository.swift
+++ b/Projects/Domain/Interface/Repository/SingleMarketTickerRepository.swift
@@ -1,0 +1,10 @@
+//
+//  SingleMarketTickerRepository.swift
+//  Domain
+//
+//  Created by choijunios on 4/14/25.
+//
+
+public protocol SingleMarketTickerRepository {
+    func request24hTicker(pairSymbol: String) -> AsyncStream<Twenty4HourTickerForSymbolVO>
+}

--- a/Projects/Domain/Interface/UseCase/CoinDetailPageUseCase.swift
+++ b/Projects/Domain/Interface/UseCase/CoinDetailPageUseCase.swift
@@ -11,4 +11,5 @@ public protocol CoinDetailPageUseCase {
     func connectToStream(symbolPair: String)
     func getWholeOrderbookTable(symbolPair: String) async throws -> OrderbookUpdateVO
     func getChangeInOrderbook(symbolPair: String) -> AsyncStream<OrderbookUpdateVO>
+    func get24hChanges(symbolPair: String) -> AsyncStream<Twenty4HourTickerForSymbolVO>
 }

--- a/Projects/Domain/Interface/UseCase/CoinDetailPageUseCase.swift
+++ b/Projects/Domain/Interface/UseCase/CoinDetailPageUseCase.swift
@@ -8,8 +8,9 @@
 import Combine
 
 public protocol CoinDetailPageUseCase {
-    func connectToStream(symbolPair: String)
+    func connectToOrederbookStream(symbolPair: String)
+    func connectToTickerChangesStream(symbolPair: String)
     func getWholeOrderbookTable(symbolPair: String) async throws -> OrderbookUpdateVO
     func getChangeInOrderbook(symbolPair: String) -> AsyncStream<OrderbookUpdateVO>
-    func get24hChanges(symbolPair: String) -> AsyncStream<Twenty4HourTickerForSymbolVO>
+    func get24hTickerChange(symbolPair: String) -> AsyncStream<Twenty4HourTickerForSymbolVO>
 }

--- a/Projects/Domain/Interface/UseCase/CoinDetailPageUseCase.swift
+++ b/Projects/Domain/Interface/UseCase/CoinDetailPageUseCase.swift
@@ -8,7 +8,7 @@
 import Combine
 
 public protocol CoinDetailPageUseCase {
-    func connectToOrederbookStream(symbolPair: String)
+    func connectToOrderbookStream(symbolPair: String)
     func connectToTickerChangesStream(symbolPair: String)
     func getWholeOrderbookTable(symbolPair: String) async throws -> OrderbookUpdateVO
     func getChangeInOrderbook(symbolPair: String) -> AsyncStream<OrderbookUpdateVO>

--- a/Projects/Domain/Tests/AllMarketTickerTests.swift
+++ b/Projects/Domain/Tests/AllMarketTickerTests.swift
@@ -28,7 +28,9 @@ struct AllMarketTickerUseCaseTests {
                 pairSymbol: "symbol\(index)USDT",
                 price: .init(100.0),
                 totalTradedQuoteAssetVolume: .init(100 + index)!,
-                changedPercent: .init(50.0)
+                changedPercent: .init(50.0),
+                bestBidPrice: .init(0.0),
+                bestAskPrice: .init(0.0)
             )
         }
         let anonymousTickers = (0..<30).map { index in
@@ -36,7 +38,9 @@ struct AllMarketTickerUseCaseTests {
                 pairSymbol: "symbol\(index)CJY",
                 price: .init(100.0),
                 totalTradedQuoteAssetVolume: .init(100 + index)!,
-                changedPercent: .init(50.0)
+                changedPercent: .init(50.0),
+                bestBidPrice: .init(0.0),
+                bestAskPrice: .init(0.0)
             )
         }
         let givenTickers = usdtTickers + anonymousTickers

--- a/Projects/Features/AllMarketTicker/Testing/FakeAllMarketTickersUseCase.swift
+++ b/Projects/Features/AllMarketTicker/Testing/FakeAllMarketTickersUseCase.swift
@@ -37,7 +37,9 @@ class FakeAllMarketTickersUseCase: AllMarketTickersUseCase {
                 pairSymbol: "test\(index)USDT",
                 price: .init(100.0 * Double.random(in: 1..<10)),
                 totalTradedQuoteAssetVolume: .init(.random(in: 100..<2000)),
-                changedPercent: .init(.random(in: -100...100))
+                changedPercent: .init(.random(in: -100...100)),
+                bestBidPrice: .init(0.0),
+                bestAskPrice: .init(0.0)
             )
         }.map { vo in
             var newVO = vo

--- a/Projects/Features/AllMarketTicker/Tests/ViewModelTests.swift
+++ b/Projects/Features/AllMarketTicker/Tests/ViewModelTests.swift
@@ -41,10 +41,10 @@ struct AllMarketTickerViewModelTests {
             alertShooter: MockAlertShooter()
         )
         let givenTickerVOs: [Twenty4HourTickerForSymbolVO] = [
-            Twenty4HourTickerForSymbolVO(pairSymbol: "test4USDT", price: 200.0, totalTradedQuoteAssetVolume: 1.0, changedPercent: 1.0),
-            Twenty4HourTickerForSymbolVO(pairSymbol: "test3USDT", price: 100.0, totalTradedQuoteAssetVolume: 1.0, changedPercent: 2.0),
-            Twenty4HourTickerForSymbolVO(pairSymbol: "test2USDT", price: 300.0, totalTradedQuoteAssetVolume: 1.0, changedPercent: 3.0),
-            Twenty4HourTickerForSymbolVO(pairSymbol: "test1USDT", price: 400.0, totalTradedQuoteAssetVolume: 1.0, changedPercent: 4.0),
+            Twenty4HourTickerForSymbolVO(pairSymbol: "test4USDT", price: 200.0, totalTradedQuoteAssetVolume: 1.0, changedPercent: 1.0, bestBidPrice: .init(0.0), bestAskPrice: .init(0.0)),
+            Twenty4HourTickerForSymbolVO(pairSymbol: "test3USDT", price: 100.0, totalTradedQuoteAssetVolume: 1.0, changedPercent: 2.0, bestBidPrice: .init(0.0), bestAskPrice: .init(0.0)),
+            Twenty4HourTickerForSymbolVO(pairSymbol: "test2USDT", price: 300.0, totalTradedQuoteAssetVolume: 1.0, changedPercent: 3.0, bestBidPrice: .init(0.0), bestAskPrice: .init(0.0)),
+            Twenty4HourTickerForSymbolVO(pairSymbol: "test1USDT", price: 400.0, totalTradedQuoteAssetVolume: 1.0, changedPercent: 4.0, bestBidPrice: .init(0.0), bestAskPrice: .init(0.0)),
         ].map { vo in
             var newVO = vo
             newVO.setSymbols(closure: { pairSymbol in

--- a/Projects/Features/CoinDetail/Example/Sources/App.swift
+++ b/Projects/Features/CoinDetail/Example/Sources/App.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-import CoinDetailFeature
+@testable import CoinDetailFeature
 import WebSocketManagementHelper
 import CoreUtil
 

--- a/Projects/Features/CoinDetail/Example/Sources/DI/Assemblies.swift
+++ b/Projects/Features/CoinDetail/Example/Sources/DI/Assemblies.swift
@@ -43,6 +43,9 @@ public class Assemblies: Assembly {
         container.register(OrderbookRepository.self) { _ in
             BinanceOrderbookRepository()
         }
+        container.register(SingleMarketTickerRepository.self) { _ in
+            BinanceSingleMarketTickerRepository()
+        }
         
         // MARK: UseCase
         container.register(CoinDetailPageUseCase.self) { _ in

--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
@@ -30,7 +30,7 @@ final class CoinDetailPageViewModel: UDFObservableObject {
     private let symbolPair: String
     private var hasAppeared = false
     private let bidStore: OrderbookStore = .init()
-    private let askStroe: OrderbookStore = .init()
+    private let askStore: OrderbookStore = .init()
 
     
     // Action
@@ -102,7 +102,7 @@ final class CoinDetailPageViewModel: UDFObservableObject {
 private extension CoinDetailPageViewModel {
     func start24hTickerStream() {
         Task {
-            useCase.connectToOrederbookStream(symbolPair: symbolPair)
+            useCase.connectToOrderbookStream(symbolPair: symbolPair)
             for await tickerVO in useCase.get24hTickerChange(symbolPair: symbolPair) {
                 let (changePercentText, changePercentTextColor) = createChangePercentTextConfig(percent: tickerVO.changedPercent)
                 action.send(.updateTickerInfo(info: .init(
@@ -139,7 +139,7 @@ private extension CoinDetailPageViewModel {
             .unretainedOnly(self)
             .asyncTransform { vm in
                 let bidList = await vm.bidStore.getDescendingList(count: 20).map(Orderbook.init)
-                let askList = await vm.askStroe.getAscendingList(count: 20).map(Orderbook.init)
+                let askList = await vm.askStore.getAscendingList(count: 20).map(Orderbook.init)
                 return Action.updateOrderbook(bids: bidList, asks: askList)
             }
             .subscribe(self.action)
@@ -171,7 +171,7 @@ private extension CoinDetailPageViewModel {
     
     func clearOrderbookStore() async {
         await bidStore.clearStore()
-        await askStroe.clearStore()
+        await askStore.clearStore()
     }
     
     func apply(bids: [Orderbook]) async {
@@ -182,7 +182,7 @@ private extension CoinDetailPageViewModel {
     
     func apply(asks: [Orderbook]) async {
         for askOrder in asks {
-            await askStroe.update(key: askOrder.price, value: askOrder.quantity)
+            await askStore.update(key: askOrder.price, value: askOrder.quantity)
         }
     }
 }

--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
@@ -11,6 +11,7 @@ import SwiftUI
 import DomainInterface
 import BaseFeature
 import CoreUtil
+import PresentationUtil
 
 enum CoinDetailPageAction {
     case onAppear

--- a/Projects/Features/CoinDetail/Feature/Sources/Model/TickerInfo.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Model/TickerInfo.swift
@@ -1,0 +1,16 @@
+//
+//  TickerInfo.swift
+//  CoinDetailModule
+//
+//  Created by choijunios on 4/14/25.
+//
+
+import SwiftUI
+
+struct TickerInfo {
+    var changePercentText: String
+    var changePercentTextColor: Color
+    var currentPriceText: String
+    var bestBidPriceText: String
+    var bestAskPriceText: String
+}

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
@@ -16,6 +16,42 @@ struct CoinDetailPageView: View {
     }
     
     var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                coinTitleContent()
+                tickerChangeInfoContent()
+                orderbookTableContent()
+            }
+        }
+        .onAppear { viewModel.action.send(.onAppear) }
+    }
+    
+    @ViewBuilder
+    private func coinTitleContent() -> some View {
+        HStack {
+            Text(viewModel.state.symbolText)
+                .font(.title)
+                .foregroundStyle(.black)
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.bottom, 5)
+        
+        Rectangle()
+            .frame(height: 1)
+            .foregroundStyle(.black)
+    }
+    
+    @ViewBuilder
+    private func tickerChangeInfoContent() -> some View {
+        TickerChangeInfoView(info: $viewModel.state.tickerInfo)
+        Rectangle()
+            .frame(height: 1)
+            .foregroundStyle(.black)
+    }
+    
+    @ViewBuilder
+    private func orderbookTableContent() -> some View {
         HStack(alignment: .top, spacing: 0) {
             VStack(spacing: 0) {
                 ForEach(Array(viewModel.state.bidOrderbooks.enumerated()), id: \.offset) { index, _ in
@@ -23,7 +59,6 @@ struct CoinDetailPageView: View {
                         .frame(height: 30)
                 }
             }
-            
             VStack(spacing: 0) {
                 ForEach(Array(viewModel.state.askOrderbooks.enumerated()), id: \.offset) { index, _ in
                     OrderbookCellView(renderObject: $viewModel.state.askOrderbooks[index])
@@ -31,6 +66,5 @@ struct CoinDetailPageView: View {
                 }
             }
         }
-        .onAppear { viewModel.action.send(.onAppear) }
     }
 }

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
@@ -7,15 +7,15 @@
 
 import SwiftUI
 
-public struct CoinDetailPageView: View {
+struct CoinDetailPageView: View {
     
     @StateObject var viewModel: CoinDetailPageViewModel
     
-    public init(viewModel: CoinDetailPageViewModel) {
+    init(viewModel: CoinDetailPageViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
     }
     
-    public var body: some View {
+    var body: some View {
         HStack(alignment: .top, spacing: 0) {
             VStack(spacing: 0) {
                 ForEach(Array(viewModel.state.bidOrderbooks.enumerated()), id: \.offset) { index, _ in

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/TickerChangeInfoView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/TickerChangeInfoView.swift
@@ -1,0 +1,50 @@
+//
+//  TickerChangeInfoView.swift
+//  CoinDetailModule
+//
+//  Created by choijunios on 4/14/25.
+//
+
+import SwiftUI
+
+struct TickerChangeInfoView: View {
+    
+    @Binding var info: TickerInfo?
+    
+    private let columns: [GridItem] = [
+        GridItem(.flexible(), alignment: .leading),
+        GridItem(.flexible(), alignment: .trailing),
+    ]
+    
+    var body: some View {
+        LazyVGrid(columns: columns) {
+            Group {
+                Text("Current price")
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 3)
+                Text(info?.currentPriceText ?? "-")
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 3)
+            }
+            Group {
+                Text("Best bid price")
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 3)
+                Text(info?.bestBidPriceText ?? "-")
+                    .foregroundStyle(.green)
+                    .padding(.horizontal, 3)
+            }
+            Group {
+                Text("Best ask price")
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 3)
+                Text(info?.bestAskPriceText ?? "-")
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 3)
+            }
+        }
+    }
+}

--- a/Projects/Utils/CoreUtil/Sources/Combine+Extension/Publisher+Ex.swift
+++ b/Projects/Utils/CoreUtil/Sources/Combine+Extension/Publisher+Ex.swift
@@ -32,4 +32,18 @@ public extension Publisher {
             }
             .eraseToAnyPublisher()
     }
+    
+    func asyncTransform<T>(transform: @escaping (Output) async -> T) -> AnyPublisher<T, Failure> {
+        
+        self
+            .flatMap { output in
+                Future<T, Failure> { promise in
+                    Task {
+                        let element = await transform(output)
+                        promise(.success(element))
+                    }
+                }
+            }
+            .eraseToAnyPublisher()
+    }
 }


### PR DESCRIPTION
## 변경된 점

- 단일 심볼 24시간 변화량 UI구현

### 단일 심볼 24시간 변화량 UI구현

바이낸스 API의 `symbol@ticker`스트림을 사용하여 최고 매도가, 매수가와 현재 가격을 표시하는 UI를 구현했습니다.
DTO는 AllMarketTicker기능 구현시 사용했던 타입을 그대로 활용하였습니다.
`Twenty4HourTickerForSymbolVO`타입에 필요한 프로퍼티를 추가하여 해당 기능에 사용했습니다. (단순 확장만 하여 기존 기능에 영향이 없도록 했습니다.)

### 시현 영상
<img src="https://github.com/user-attachments/assets/cadb61c3-8344-4bcc-967d-5628d445a2d8" width=300 />
