### PR TITLE
[CVW-033] 최근 거래정보 조회 UI구현

### DIFF
--- a/Projects/Data/DataSource/Sources/DTO/BinanceCoinTradeDTO.swift
+++ b/Projects/Data/DataSource/Sources/DTO/BinanceCoinTradeDTO.swift
@@ -1,11 +1,11 @@
 //
-//  TradeDTO.swift
+//  BinanceCoinTradeDTO.swift
 //  Data
 //
 //  Created by choijunios on 4/15/25.
 //
 
-public struct TradeDTO: Decodable {
+public struct BinanceCoinTradeDTO: Decodable {
     public let eventType: String          // "e": "trade"
     public let eventTime: Int64           // "E": 1672515782136
     public let symbol: String             // "s": "BNBBTC"

--- a/Projects/Data/DataSource/Sources/DTO/TradeDTO.swift
+++ b/Projects/Data/DataSource/Sources/DTO/TradeDTO.swift
@@ -1,0 +1,28 @@
+//
+//  TradeDTO.swift
+//  Data
+//
+//  Created by choijunios on 4/15/25.
+//
+
+public struct TradeDTO: Decodable {
+    public let eventType: String          // "e": "trade"
+    public let eventTime: Int64           // "E": 1672515782136
+    public let symbol: String             // "s": "BNBBTC"
+    public let tradeID: Int               // "t": 12345
+    public let price: String              // "p": "0.001"
+    public let quantity: String           // "q": "100"
+    public let tradeTime: Int64           // "T": 1672515782136
+    public let isBuyerMarketMaker: Bool   // "m": true
+
+    enum CodingKeys: String, CodingKey {
+        case eventType = "e"
+        case eventTime = "E"
+        case symbol = "s"
+        case tradeID = "t"
+        case price = "p"
+        case quantity = "q"
+        case tradeTime = "T"
+        case isBuyerMarketMaker = "m"
+    }
+}

--- a/Projects/Data/Repository/Sources/BinanceOrderbookRepository.swift
+++ b/Projects/Data/Repository/Sources/BinanceOrderbookRepository.swift
@@ -18,7 +18,7 @@ final public class BinanceOrderbookRepository: OrderbookRepository {
     
     public init() { }
     
-    public func getWhileTable(symbolPair: String) async throws -> OrderbookUpdateVO {
+    public func getWholeTable(symbolPair: String) async throws -> OrderbookUpdateVO {
         let requestBuiler = URLRequestBuilder(
             base: .init(string: "https://api.binance.com/api/v3")!,
             httpMethod: .get

--- a/Projects/Data/Repository/Sources/BinanceTradeRepository.swift
+++ b/Projects/Data/Repository/Sources/BinanceTradeRepository.swift
@@ -1,0 +1,34 @@
+//
+//  BinanceTradeRepository.swift
+//  Data
+//
+//  Created by choijunios on 4/15/25.
+//
+
+import DomainInterface
+import DataSource
+import CoreUtil
+
+final public class BinanceTradeRepository: TradeRepository {
+    @Injected private var webSocketService: WebSocketService
+    
+    public init() { }
+    
+    public func getSingleTrade(symbolPair: String) -> AsyncStream<CoinTradeVO> {
+        let publisher = webSocketService
+            .getMessageStream()
+            .filter({ (dto: BinanceCoinTradeDTO) in
+                dto.symbol.lowercased() == symbolPair.lowercased()
+            })
+            .map({ $0.toEntity() })
+            return AsyncStream { continuation in
+                let cancellable = publisher
+                    .sink(receiveValue: { entity in
+                        continuation.yield(entity)
+                    })
+                continuation.onTermination = { @Sendable _ in
+                    cancellable.cancel()
+                }
+            }
+    }
+}

--- a/Projects/Data/Repository/Sources/ToEntityExtension/BinanceCoinTradeDTO+toEntity.swift
+++ b/Projects/Data/Repository/Sources/ToEntityExtension/BinanceCoinTradeDTO+toEntity.swift
@@ -16,8 +16,8 @@ extension BinanceCoinTradeDTO {
         .init(
             tradeId: String(tradeID),
             tradeType: isBuyerMarketMaker ? .sell : .buy,
-            price: CVNumber(Decimal(string: self.price)!),
-            quantity: CVNumber(Decimal(string: self.quantity)!),
+            price: CVNumber(Decimal(string: self.price) ?? Decimal.zero),
+            quantity: CVNumber(Decimal(string: self.quantity) ?? Decimal.zero),
             tradeTime: Date(timeIntervalSince1970: TimeInterval(eventTime) / 1000)
         )
     }

--- a/Projects/Data/Repository/Sources/ToEntityExtension/BinanceCoinTradeDTO+toEntity.swift
+++ b/Projects/Data/Repository/Sources/ToEntityExtension/BinanceCoinTradeDTO+toEntity.swift
@@ -1,0 +1,22 @@
+//
+//  BinanceCoinTradeDTO+toEntity.swift
+//  Data
+//
+//  Created by choijunios on 4/15/25.
+//
+
+import Foundation
+
+import DomainInterface
+import DataSource
+import CoreUtil
+
+extension BinanceCoinTradeDTO {
+    func toEntity() -> CoinTradeVO {
+        .init(
+            price: CVNumber(Decimal(string: self.price)!),
+            quantity: CVNumber(Decimal(string: self.quantity)!),
+            tradeTime: Date(timeIntervalSince1970: TimeInterval(eventTime) / 1000)
+        )
+    }
+}

--- a/Projects/Data/Repository/Sources/ToEntityExtension/BinanceCoinTradeDTO+toEntity.swift
+++ b/Projects/Data/Repository/Sources/ToEntityExtension/BinanceCoinTradeDTO+toEntity.swift
@@ -14,6 +14,8 @@ import CoreUtil
 extension BinanceCoinTradeDTO {
     func toEntity() -> CoinTradeVO {
         .init(
+            tradeId: String(tradeID),
+            tradeType: isBuyerMarketMaker ? .sell : .buy,
             price: CVNumber(Decimal(string: self.price)!),
             quantity: CVNumber(Decimal(string: self.quantity)!),
             tradeTime: Date(timeIntervalSince1970: TimeInterval(eventTime) / 1000)

--- a/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
@@ -32,7 +32,7 @@ public extension DefaultCoinDetailPageUseCase {
     }
     
     func getWholeOrderbookTable(symbolPair: String) async throws -> OrderbookUpdateVO {
-        try await orderbookRepository.getWhileTable(symbolPair: symbolPair)
+        try await orderbookRepository.getWholeTable(symbolPair: symbolPair)
     }
     
     func getChangeInOrderbook(symbolPair: String) -> AsyncStream<OrderbookUpdateVO> {

--- a/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
@@ -15,6 +15,7 @@ final public class DefaultCoinDetailPageUseCase: CoinDetailPageUseCase {
 
     @Injected private var orderbookRepository: OrderbookRepository
     @Injected private var singleTickerRepository: SingleMarketTickerRepository
+    @Injected private var coinTradeRepository: TradeRepository
     @Injected private var webSocketHelper: WebSocketManagementHelper
     
     public init() { }
@@ -31,6 +32,10 @@ public extension DefaultCoinDetailPageUseCase {
         webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@ticker"])
     }
     
+    func connectToRecentTradeStream(symbolPair: String) {
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@trade"])
+    }
+    
     func getWholeOrderbookTable(symbolPair: String) async throws -> OrderbookUpdateVO {
         try await orderbookRepository.getWholeTable(symbolPair: symbolPair)
     }
@@ -41,5 +46,9 @@ public extension DefaultCoinDetailPageUseCase {
     
     func get24hTickerChange(symbolPair: String) -> AsyncStream<Twenty4HourTickerForSymbolVO> {
         singleTickerRepository.request24hTickerChange(pairSymbol: symbolPair)
+    }
+    
+    func getRecentTrade(symbolPair: String) -> AsyncStream<CoinTradeVO> {
+        coinTradeRepository.getSingleTrade(symbolPair: symbolPair)
     }
 }

--- a/Projects/Domain/Interface/Entity/Trade/CoinTradeVO.swift
+++ b/Projects/Domain/Interface/Entity/Trade/CoinTradeVO.swift
@@ -10,11 +10,19 @@ import Foundation
 import CoreUtil
 
 public struct CoinTradeVO {
+    public enum TradeType {
+        case buy, sell
+    }
+    
+    public let tradeId: String
+    public let tradeType: TradeType
     public let price: CVNumber
     public let quantity: CVNumber
     public let tradeTime: Date
     
-    public init(price: CVNumber, quantity: CVNumber, tradeTime: Date) {
+    public init(tradeId: String, tradeType: TradeType, price: CVNumber, quantity: CVNumber, tradeTime: Date) {
+        self.tradeId = tradeId
+        self.tradeType = tradeType
         self.price = price
         self.quantity = quantity
         self.tradeTime = tradeTime

--- a/Projects/Domain/Interface/Entity/Trade/CoinTradeVO.swift
+++ b/Projects/Domain/Interface/Entity/Trade/CoinTradeVO.swift
@@ -7,12 +7,14 @@
 
 import Foundation
 
+import CoreUtil
+
 public struct CoinTradeVO {
-    public let price: Decimal
-    public let quantity: Decimal
+    public let price: CVNumber
+    public let quantity: CVNumber
     public let tradeTime: Date
     
-    public init(price: Decimal, quantity: Decimal, tradeTime: Date) {
+    public init(price: CVNumber, quantity: CVNumber, tradeTime: Date) {
         self.price = price
         self.quantity = quantity
         self.tradeTime = tradeTime

--- a/Projects/Domain/Interface/Entity/Trade/CoinTradeVO.swift
+++ b/Projects/Domain/Interface/Entity/Trade/CoinTradeVO.swift
@@ -1,0 +1,20 @@
+//
+//  CoinTradeVO.swift
+//  Domain
+//
+//  Created by choijunios on 4/15/25.
+//
+
+import Foundation
+
+public struct CoinTradeVO {
+    public let price: Decimal
+    public let quantity: Decimal
+    public let tradeTime: Date
+    
+    public init(price: Decimal, quantity: Decimal, tradeTime: Date) {
+        self.price = price
+        self.quantity = quantity
+        self.tradeTime = tradeTime
+    }
+}

--- a/Projects/Domain/Interface/Repository/OrderbookRepository.swift
+++ b/Projects/Domain/Interface/Repository/OrderbookRepository.swift
@@ -8,6 +8,6 @@
 import Combine
 
 public protocol OrderbookRepository {
-    func getWhileTable(symbolPair: String) async throws -> OrderbookUpdateVO
+    func getWholeTable(symbolPair: String) async throws -> OrderbookUpdateVO
     func getUpdate(symbolPair: String) -> AsyncStream<OrderbookUpdateVO>
 }

--- a/Projects/Domain/Interface/Repository/TradeRepository.swift
+++ b/Projects/Domain/Interface/Repository/TradeRepository.swift
@@ -1,0 +1,10 @@
+//
+//  TradeRepository.swift
+//  Domain
+//
+//  Created by choijunios on 4/15/25.
+//
+
+public protocol TradeRepository {
+    func getSingleTrade(pairSymbol: String) -> AsyncStream<CoinTradeVO>
+}

--- a/Projects/Domain/Interface/Repository/TradeRepository.swift
+++ b/Projects/Domain/Interface/Repository/TradeRepository.swift
@@ -6,5 +6,5 @@
 //
 
 public protocol TradeRepository {
-    func getSingleTrade(pairSymbol: String) -> AsyncStream<CoinTradeVO>
+    func getSingleTrade(symbolPair: String) -> AsyncStream<CoinTradeVO>
 }

--- a/Projects/Domain/Interface/UseCase/CoinDetailPageUseCase.swift
+++ b/Projects/Domain/Interface/UseCase/CoinDetailPageUseCase.swift
@@ -10,7 +10,10 @@ import Combine
 public protocol CoinDetailPageUseCase {
     func connectToOrderbookStream(symbolPair: String)
     func connectToTickerChangesStream(symbolPair: String)
+    func connectToRecentTradeStream(symbolPair: String)
+    
     func getWholeOrderbookTable(symbolPair: String) async throws -> OrderbookUpdateVO
     func getChangeInOrderbook(symbolPair: String) -> AsyncStream<OrderbookUpdateVO>
     func get24hTickerChange(symbolPair: String) -> AsyncStream<Twenty4HourTickerForSymbolVO>
+    func getRecentTrade(symbolPair: String) -> AsyncStream<CoinTradeVO>
 }

--- a/Projects/Features/CoinDetail/Example/Sources/DI/Assemblies.swift
+++ b/Projects/Features/CoinDetail/Example/Sources/DI/Assemblies.swift
@@ -46,6 +46,9 @@ public class Assemblies: Assembly {
         container.register(SingleMarketTickerRepository.self) { _ in
             BinanceSingleMarketTickerRepository()
         }
+        container.register(TradeRepository.self) { _ in
+            BinanceTradeRepository()
+        }
         
         // MARK: UseCase
         container.register(CoinDetailPageUseCase.self) { _ in

--- a/Projects/Features/CoinDetail/Feature/Sources/Model/CoinTradeRO.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Model/CoinTradeRO.swift
@@ -1,0 +1,17 @@
+//
+//  CoinTradeRO.swift
+//  CoinDetailModule
+//
+//  Created by choijunios on 4/15/25.
+//
+
+import SwiftUI
+
+struct CoinTradeRO: Identifiable {
+    let id: String
+    let priceText: String
+    let quantityText: String
+    let timeText: String
+    let textColor: Color
+    let backgroundEffectColor: Color
+}

--- a/Projects/Features/CoinDetail/Feature/Sources/Model/CoinTradeRO.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Model/CoinTradeRO.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct CoinTradeRO: Identifiable {
+struct CoinTradeRO: Identifiable, Equatable {
     let id: String
     let priceText: String
     let quantityText: String

--- a/Projects/Features/CoinDetail/Feature/Sources/Util/TradeContainer.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Util/TradeContainer.swift
@@ -1,0 +1,30 @@
+//
+//  TradeContainer.swift
+//  CoinDetailModule
+//
+//  Created by choijunios on 4/15/25.
+//
+
+import DomainInterface
+
+actor TradeContainer {
+    private let maxCount: Int
+    private var trades: [CoinTradeVO]
+    
+    init(maxCount: Int, trades: [CoinTradeVO] = []) {
+        self.maxCount = maxCount
+        self.trades = trades
+    }
+    
+    func insert(element newTrade: CoinTradeVO) {
+        if !trades.contains(where: { $0.tradeId == newTrade.tradeId }) {
+            trades.append(newTrade)
+            trades.sort(by: { $0.tradeTime > $1.tradeTime })
+            if trades.count > maxCount {
+                trades = Array(trades.prefix(upTo: maxCount))
+            }
+        }
+    }
+    
+    func getList() -> [CoinTradeVO] { return trades }
+}

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
@@ -21,6 +21,7 @@ struct CoinDetailPageView: View {
                 coinTitleContent()
                 tickerChangeInfoContent()
                 orderbookTableContent()
+                recentTradeContent()
             }
         }
         .onAppear { viewModel.action.send(.onAppear) }
@@ -66,5 +67,10 @@ struct CoinDetailPageView: View {
                 }
             }
         }
+    }
+    
+    @ViewBuilder
+    private func recentTradeContent() -> some View {
+        RecentTradeTableView(trades: $viewModel.state.trades)
     }
 }

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
@@ -19,8 +19,11 @@ struct CoinDetailPageView: View {
         ScrollView {
             VStack(spacing: 0) {
                 coinTitleContent()
+                Divider()
                 tickerChangeInfoContent()
+                Divider()
                 orderbookTableContent()
+                Divider()
                 recentTradeContent()
             }
         }
@@ -35,35 +38,45 @@ struct CoinDetailPageView: View {
                 .foregroundStyle(.black)
             Spacer()
         }
-        .padding(.horizontal, 10)
+        .padding(.horizontal, 3)
         .padding(.bottom, 5)
-        
-        Rectangle()
-            .frame(height: 1)
-            .foregroundStyle(.black)
     }
     
     @ViewBuilder
     private func tickerChangeInfoContent() -> some View {
         TickerChangeInfoView(info: $viewModel.state.tickerInfo)
-        Rectangle()
-            .frame(height: 1)
-            .foregroundStyle(.black)
     }
     
     @ViewBuilder
     private func orderbookTableContent() -> some View {
-        HStack(alignment: .top, spacing: 0) {
-            VStack(spacing: 0) {
-                ForEach(Array(viewModel.state.bidOrderbooks.enumerated()), id: \.offset) { index, _ in
-                    OrderbookCellView(renderObject: $viewModel.state.bidOrderbooks[index])
-                        .frame(height: 30)
-                }
+        VStack(spacing: 0) {
+            HStack {
+                Text("Qty")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text("Price")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                Text("Qty")
+                    .frame(maxWidth: .infinity, alignment: .trailing)
             }
-            VStack(spacing: 0) {
-                ForEach(Array(viewModel.state.askOrderbooks.enumerated()), id: \.offset) { index, _ in
-                    OrderbookCellView(renderObject: $viewModel.state.askOrderbooks[index])
-                        .frame(height: 30)
+            .font(.subheadline.bold())
+            .foregroundColor(.gray)
+            .padding(.horizontal, 3)
+            .padding(.vertical, 7)
+            
+            Divider()
+            
+            HStack(alignment: .top, spacing: 0) {
+                VStack(spacing: 0) {
+                    ForEach(Array(viewModel.state.bidOrderbooks.enumerated()), id: \.offset) { index, _ in
+                        OrderbookCellView(renderObject: $viewModel.state.bidOrderbooks[index])
+                            .frame(height: 30)
+                    }
+                }
+                VStack(spacing: 0) {
+                    ForEach(Array(viewModel.state.askOrderbooks.enumerated()), id: \.offset) { index, _ in
+                        OrderbookCellView(renderObject: $viewModel.state.askOrderbooks[index])
+                            .frame(height: 30)
+                    }
                 }
             }
         }

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/OrderbookCellView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/OrderbookCellView.swift
@@ -14,7 +14,8 @@ struct OrderbookCellView: View {
     var body: some View {
         ZStack {
             quantityGageContent()
-            HStack { textContent() }
+            textContent()
+                .padding(.horizontal, 3)
         }
     }
     
@@ -45,19 +46,23 @@ struct OrderbookCellView: View {
     
     @ViewBuilder
     private func textContent() -> some View {
-        switch renderObject.textAlignment {
-        case .priceFirst:
-            Text(renderObject.priceText)
-                .foregroundStyle(renderObject.priceTextColor)
-            Spacer()
-            Text(renderObject.quantityText)
-                .foregroundStyle(.black)
-        case .quantityFirst:
-            Text(renderObject.quantityText)
-                .foregroundStyle(.black)
-            Spacer()
-            Text(renderObject.priceText)
-                .foregroundStyle(renderObject.priceTextColor)
+        HStack {
+            switch renderObject.textAlignment {
+            case .priceFirst:
+                Text(renderObject.priceText)
+                    .foregroundStyle(renderObject.priceTextColor)
+                Spacer()
+                Text(renderObject.quantityText)
+                    .foregroundStyle(.black)
+            case .quantityFirst:
+                Text(renderObject.quantityText)
+                    .foregroundStyle(.black)
+                Spacer()
+                Text(renderObject.priceText)
+                    .foregroundStyle(renderObject.priceTextColor)
+            }
         }
+        .monospaced()
+        .font(.subheadline.bold())
     }
 }

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/RecentTradeRowView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/RecentTradeRowView.swift
@@ -1,0 +1,46 @@
+//
+//  RecentTradeRowView.swift
+//  CoinDetailModule
+//
+//  Created by choijunios on 4/15/25.
+//
+
+import SwiftUI
+
+struct RecentTradeRowView: View {
+    
+    @Binding var trade: CoinTradeRO
+    @State private var backgroundAlpha = 0.3
+    
+    var body: some View {
+        HStack {
+            Text(trade.priceText)
+                .foregroundColor(trade.textColor)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .monospacedDigit()
+                .padding(.horizontal)
+            
+            Text(trade.quantityText)
+                .foregroundColor(trade.textColor)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .monospacedDigit()
+                .padding(.trailing, 40)
+            
+            Text(trade.timeText)
+                .foregroundColor(trade.textColor)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .monospacedDigit()
+                .padding(.horizontal)
+        }
+        .font(.system(size: 14))
+        .padding(.vertical, 5)
+        .background(trade.backgroundEffectColor.opacity(backgroundAlpha))
+        .onAppear(perform: {
+            withAnimation(.easeInOut(duration: 0.2)) { backgroundAlpha = 0 }
+        })
+        .onChange(of: trade) { _, _ in
+            backgroundAlpha = 0.3
+            withAnimation(.easeInOut(duration: 0.2)) { backgroundAlpha = 0 }
+        }
+    }
+}

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/RecentTradeRowView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/RecentTradeRowView.swift
@@ -18,7 +18,7 @@ struct RecentTradeRowView: View {
                 .foregroundColor(trade.textColor)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .monospacedDigit()
-                .padding(.horizontal)
+                .padding(.horizontal, 3)
             
             Text(trade.quantityText)
                 .foregroundColor(trade.textColor)
@@ -30,17 +30,17 @@ struct RecentTradeRowView: View {
                 .foregroundColor(trade.textColor)
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .monospacedDigit()
-                .padding(.horizontal)
+                .padding(.horizontal, 3)
         }
         .font(.system(size: 14))
-        .padding(.vertical, 5)
+        .padding(.vertical, 7)
         .background(trade.backgroundEffectColor.opacity(backgroundAlpha))
         .onAppear(perform: {
-            withAnimation(.easeInOut(duration: 0.2)) { backgroundAlpha = 0 }
+            withAnimation(.easeInOut(duration: 1.0)) { backgroundAlpha = 0 }
         })
         .onChange(of: trade) { _, _ in
             backgroundAlpha = 0.3
-            withAnimation(.easeInOut(duration: 0.2)) { backgroundAlpha = 0 }
+            withAnimation(.easeInOut(duration: 1.0)) { backgroundAlpha = 0 }
         }
     }
 }

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/RecentTradeTableView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/RecentTradeTableView.swift
@@ -23,9 +23,9 @@ struct RecentTradeTableView: View {
                     .frame(maxWidth: .infinity, alignment: .trailing)
             }
             .font(.subheadline.bold())
-            .padding(.horizontal)
-            .padding(.vertical, 8)
             .foregroundColor(.gray)
+            .padding(.horizontal, 3)
+            .padding(.vertical, 8)
             
             Divider()
             
@@ -36,7 +36,6 @@ struct RecentTradeTableView: View {
                         RecentTradeRowView(trade: $trades[index])
                     }
                 }
-                .padding(.vertical, 8)
             }
         }
     }

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/RecentTradeTableView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/RecentTradeTableView.swift
@@ -1,0 +1,43 @@
+//
+//  RecentTradeTableView.swift
+//  CoinDetailModule
+//
+//  Created by choijunios on 4/15/25.
+//
+
+import SwiftUI
+
+struct RecentTradeTableView: View {
+    
+    @Binding var trades: [CoinTradeRO]
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Price")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text("Qty")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                Text("Time")
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .font(.subheadline.bold())
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .foregroundColor(.gray)
+            
+            Divider()
+            
+            // Rows
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(trades.enumerated()), id: \.element.id) { index, _ in
+                        RecentTradeRowView(trade: $trades[index])
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+        }
+    }
+}

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/TickerChangeInfoView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/TickerChangeInfoView.swift
@@ -17,34 +17,33 @@ struct TickerChangeInfoView: View {
     ]
     
     var body: some View {
-        LazyVGrid(columns: columns) {
+        LazyVGrid(columns: columns, spacing: 4) {
             Group {
                 Text("Current price")
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.black)
                     .padding(.horizontal, 3)
                 Text(info?.currentPriceText ?? "-")
                     .foregroundStyle(.black)
                     .padding(.horizontal, 3)
+                    .monospaced()
             }
             Group {
                 Text("Best bid price")
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.black)
                     .padding(.horizontal, 3)
                 Text(info?.bestBidPriceText ?? "-")
                     .foregroundStyle(.green)
                     .padding(.horizontal, 3)
+                    .monospaced()
             }
             Group {
                 Text("Best ask price")
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.black)
                     .padding(.horizontal, 3)
                 Text(info?.bestAskPriceText ?? "-")
                     .foregroundStyle(.red)
                     .padding(.horizontal, 3)
+                    .monospaced()
             }
         }
+        .font(.subheadline.bold())
+        .foregroundColor(.gray)
     }
 }


### PR DESCRIPTION
## 변경된 점

- 최근 거래정보를 불러오는 스트림과 정보를 표시하는 UI를 구현했습니다.

### 최근 거래정보 표시

데이터 처리과정
1. 실시간 거래정보를 웹소캣으로 가져옵니다.
2. ViewModel에서 거래 id당 하나의 거래정보만 저장되도록 관리합니다.
3. throttle을 사용해 데이터 업데이트와 별개로 0.5간격으로 UI를 업데이트합니다.
4. 가장 최신데이터 15개를 화면에 표시합니다.

해당과정에서 동시성을 방지하기 위해 **TradeContainer**타입을 actor로 구현했습니다.

### 시현 영상

ForEach로 반환되는 뷰들은 거래 id를 기반으로 식별됩니다. 새로운 거래 정보가 화면에 추가되는 경우 1초간 배경이 반짝입니다.

<img src="https://github.com/user-attachments/assets/19f10afb-4246-4178-8028-5e17581dfd12" width=300 />