### PR TITLE
[CVW-035] 디테일 화면 웹소켓 스트림 연결 관리 구현

### DIFF
--- a/Plugins/ConfigurationPlugin/ProjectDescriptionHelpers/InfoPlist.swift
+++ b/Plugins/ConfigurationPlugin/ProjectDescriptionHelpers/InfoPlist.swift
@@ -32,6 +32,7 @@ extension InfoPlist {
                 ]
             ]
         ],
+        "UIUserInterfaceStyle": "Light",
         
         // API keys
         "OPENEX_API_KEY": "$(OPENEX_API_KEY)"

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -18,12 +18,10 @@ class SceneDelegate: NSObject, UISceneDelegate {
     
     // MARK: App life cycle management
     func sceneDidEnterBackground(_ scene: UIScene) {
-        webSocketManagementHelper
-            .requestDisconnection()
+        webSocketManagementHelper.requestDisconnection()
     }
     
     func sceneWillEnterForeground(_ scene: UIScene) {
-        webSocketManagementHelper
-            .requestConnection(connectionType: .recoverPreviousStreams)
+        webSocketManagementHelper.requestConnection(connectionType: .freshStart)
     }
 }

--- a/Projects/Data/DataSource/Sources/Service/Network/WebSocket/WebSocketService.swift
+++ b/Projects/Data/DataSource/Sources/Service/Network/WebSocket/WebSocketService.swift
@@ -35,9 +35,9 @@ public protocol WebSocketService: AnyObject {
     
     
     /// 특정 스트림에 구독할 것을 요청합니다.
-    func subscribeTo(message: [String], completion: @escaping WebsocketCompletion)
+    func subscribeTo(message: [String], mustDeliver: Bool, completion: @escaping WebsocketCompletion)
     
     
     /// 특정 스트림에 구독을 해제할 것을 요청합니다.
-    func unsubscribeTo(message: [String], completion: @escaping WebsocketCompletion)
+    func unsubscribeTo(message: [String], mustDeliver: Bool, completion: @escaping WebsocketCompletion)
 }

--- a/Projects/Data/Repository/Sources/BinanceAllMarketTickersRepository.swift
+++ b/Projects/Data/Repository/Sources/BinanceAllMarketTickersRepository.swift
@@ -13,8 +13,7 @@ import DomainInterface
 import CoreUtil
 
 public class BinanceAllMarketTickersRepository: AllMarketTickersRepository {
-    
-    // Service locator
+    // Dependency
     @Injected var webSocketService: WebSocketService
     
     public init() { }

--- a/Projects/Data/Repository/Sources/BinanceOrderbookRepository.swift
+++ b/Projects/Data/Repository/Sources/BinanceOrderbookRepository.swift
@@ -39,14 +39,14 @@ final public class BinanceOrderbookRepository: OrderbookRepository {
                 dto.symbol.lowercased() == symbolPair.lowercased()
             })
             .map({ $0.toEntity() })
-            return AsyncStream { continuation in
-                let cancellable = publisher
-                    .sink(receiveValue: { entity in
-                        continuation.yield(entity)
-                    })
-                continuation.onTermination = { @Sendable _ in
-                    cancellable.cancel()
-                }
+        return AsyncStream { continuation in
+            let cancellable = publisher
+                .sink(receiveValue: { entity in
+                    continuation.yield(entity)
+                })
+            continuation.onTermination = { @Sendable [cancellable] _ in
+                cancellable.cancel()
             }
+        }
     }
 }

--- a/Projects/Data/Repository/Sources/BinanceSingleMarketTickerRepository.swift
+++ b/Projects/Data/Repository/Sources/BinanceSingleMarketTickerRepository.swift
@@ -10,7 +10,7 @@ import DataSource
 import CoreUtil
 
 final public class BinanceSingleMarketTickerRepository: SingleMarketTickerRepository {
-    
+    // Dependency
     @Injected private var webSocketService: WebSocketService
     
     public init() { }

--- a/Projects/Data/Repository/Sources/BinanceTradeRepository.swift
+++ b/Projects/Data/Repository/Sources/BinanceTradeRepository.swift
@@ -10,6 +10,7 @@ import DataSource
 import CoreUtil
 
 final public class BinanceTradeRepository: TradeRepository {
+    // Dependency
     @Injected private var webSocketService: WebSocketService
     
     public init() { }

--- a/Projects/Data/Repository/Sources/DefaultExchangeRateRepository.swift
+++ b/Projects/Data/Repository/Sources/DefaultExchangeRateRepository.swift
@@ -17,8 +17,7 @@ import CoreUtil
 import SwiftStructures
 
 public class DefaultExchangeRateRepository: ExchangeRateRepository {
-    
-    // Service locator
+    // Dependency
     @Injected private var priceService: ExchangeRateService
     
     // Cache (base: [to: rate])

--- a/Projects/Data/Repository/Sources/DefaultUserConfigurationRepository.swift
+++ b/Projects/Data/Repository/Sources/DefaultUserConfigurationRepository.swift
@@ -15,14 +15,11 @@ import CoreUtil
 import SwiftStructures
 
 public class DefaultUserConfigurationRepository: UserConfigurationRepository {
-    
-    // Service locator
+    // Dependency
     @Injected var userConfigurationService: UserConfigurationService
-    
     
     // Cache configuration
     private let cachedConfiguration: LockedDictionary<String, Any> = .init()
-    
     
     public init() { }
     

--- a/Projects/Domain/Concrete/UseCase/DefaultAllMarketTickersUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultAllMarketTickersUseCase.swift
@@ -31,7 +31,7 @@ public final class DefaultAllMarketTickersUseCase: AllMarketTickersUseCase {
     
     public func prepareStream() {
         webSocketManagementHelper
-            .requestSubscribeToStream(streams: ["!ticker@arr"])
+            .requestSubscribeToStream(streams: ["!ticker@arr"], autoReconnectionEnabled: true)
     }
     
     

--- a/Projects/Domain/Concrete/UseCase/DefaultAllMarketTickersUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultAllMarketTickersUseCase.swift
@@ -14,8 +14,7 @@ import WebSocketManagementHelper
 import CoreUtil
 
 public final class DefaultAllMarketTickersUseCase: AllMarketTickersUseCase {
-    
-    // Service locator
+    // Dependency
     @Injected private var allMarketTickersRepository: AllMarketTickersRepository
     @Injected private var webSocketManagementHelper: WebSocketManagementHelper
     

--- a/Projects/Domain/Concrete/UseCase/DefaultAllMarketTickersUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultAllMarketTickersUseCase.swift
@@ -31,7 +31,7 @@ public final class DefaultAllMarketTickersUseCase: AllMarketTickersUseCase {
     
     public func prepareStream() {
         webSocketManagementHelper
-            .requestSubscribeToStream(streams: ["!ticker@arr"], autoReconnectionEnabled: true)
+            .requestSubscribeToStream(streams: ["!ticker@arr"])
     }
     
     

--- a/Projects/Domain/Concrete/UseCase/DefaultAllMarketTickersUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultAllMarketTickersUseCase.swift
@@ -28,12 +28,13 @@ public final class DefaultAllMarketTickersUseCase: AllMarketTickersUseCase {
     
     public init() { }
     
-    
-    public func prepareStream() {
-        webSocketManagementHelper
-            .requestSubscribeToStream(streams: ["!ticker@arr"])
+    public func connectToAllMarketTickerStream() {
+        webSocketManagementHelper.requestSubscribeToStream(streams: ["!ticker@arr"], mustDeliver: true)
     }
     
+    public func disConnectToAllMarketTickerStream() {
+        webSocketManagementHelper.requestUnsubscribeToStream(streams: ["!ticker@arr"], mustDeliver: false)
+    }
     
     public func requestTickers() -> AnyPublisher<[Twenty4HourTickerForSymbolVO], Never> {
         

--- a/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
@@ -25,15 +25,15 @@ final public class DefaultCoinDetailPageUseCase: CoinDetailPageUseCase {
 // MARK: Orderbook
 public extension DefaultCoinDetailPageUseCase {
     func connectToOrderbookStream(symbolPair: String) {
-        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@depth"])
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@depth"], mustDeliver: true)
     }
     
     func connectToTickerChangesStream(symbolPair: String) {
-        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@ticker"])
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@ticker"], mustDeliver: true)
     }
     
     func connectToRecentTradeStream(symbolPair: String) {
-        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@trade"])
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@trade"], mustDeliver: true)
     }
     
     func disconnectToStreams(symbolPair: String) {
@@ -42,7 +42,7 @@ public extension DefaultCoinDetailPageUseCase {
             "\(symbol)@depth",
             "\(symbol)@ticker",
             "\(symbol)@trade",
-        ])
+        ], mustDeliver: false)
     }
     
     func getWholeOrderbookTable(symbolPair: String) async throws -> OrderbookUpdateVO {

--- a/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
@@ -12,7 +12,7 @@ import WebSocketManagementHelper
 import CoreUtil
 
 final public class DefaultCoinDetailPageUseCase: CoinDetailPageUseCase {
-
+    // Dependency
     @Injected private var orderbookRepository: OrderbookRepository
     @Injected private var singleTickerRepository: SingleMarketTickerRepository
     @Injected private var coinTradeRepository: TradeRepository

--- a/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
@@ -25,15 +25,15 @@ final public class DefaultCoinDetailPageUseCase: CoinDetailPageUseCase {
 // MARK: Orderbook
 public extension DefaultCoinDetailPageUseCase {
     func connectToOrderbookStream(symbolPair: String) {
-        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@depth"], autoReconnectionEnabled: false)
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@depth"])
     }
     
     func connectToTickerChangesStream(symbolPair: String) {
-        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@ticker"], autoReconnectionEnabled: true)
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@ticker"])
     }
     
     func connectToRecentTradeStream(symbolPair: String) {
-        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@trade"], autoReconnectionEnabled: true)
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@trade"])
     }
     
     func disconnectToStreams(symbolPair: String) {

--- a/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
@@ -25,15 +25,15 @@ final public class DefaultCoinDetailPageUseCase: CoinDetailPageUseCase {
 // MARK: Orderbook
 public extension DefaultCoinDetailPageUseCase {
     func connectToOrderbookStream(symbolPair: String) {
-        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@depth"])
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@depth"], autoReconnectionEnabled: false)
     }
     
     func connectToTickerChangesStream(symbolPair: String) {
-        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@ticker"])
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@ticker"], autoReconnectionEnabled: true)
     }
     
     func connectToRecentTradeStream(symbolPair: String) {
-        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@trade"])
+        webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@trade"], autoReconnectionEnabled: true)
     }
     
     func disconnectToStreams(symbolPair: String) {

--- a/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultCoinDetailPageUseCase.swift
@@ -36,6 +36,15 @@ public extension DefaultCoinDetailPageUseCase {
         webSocketHelper.requestSubscribeToStream(streams: ["\(symbolPair.lowercased())@trade"])
     }
     
+    func disconnectToStreams(symbolPair: String) {
+        let symbol = symbolPair.lowercased()
+        webSocketHelper.requestUnsubscribeToStream(streams: [
+            "\(symbol)@depth",
+            "\(symbol)@ticker",
+            "\(symbol)@trade",
+        ])
+    }
+    
     func getWholeOrderbookTable(symbolPair: String) async throws -> OrderbookUpdateVO {
         try await orderbookRepository.getWholeTable(symbolPair: symbolPair)
     }

--- a/Projects/Domain/Concrete/UseCase/DefaultExchangeRateUseCase.swift
+++ b/Projects/Domain/Concrete/UseCase/DefaultExchangeRateUseCase.swift
@@ -15,8 +15,7 @@ import I18N
 import CoreUtil
 
 public final class DefaultExchangeRateUseCase: ExchangeRateUseCase {
-    
-    // Service locator
+    // Dependency
     @Injected private var exchangeRateRepository: ExchangeRateRepository
     @Injected private var alertShooter: AlertShooter
     

--- a/Projects/Domain/Interface/UseCase/AllMarketTickersUseCase.swift
+++ b/Projects/Domain/Interface/UseCase/AllMarketTickersUseCase.swift
@@ -9,8 +9,11 @@ import Combine
 
 public protocol AllMarketTickersUseCase {
     
-    /// AllMarketTicker스트림을 준비합니다.
-    func prepareStream()
+    /// AllMarketTicker스트림을 구독합니다.
+    func connectToAllMarketTickerStream()
+    
+    /// 스트림 연결을 해제합니다.
+    func disConnectToAllMarketTickerStream()
     
     /// AllMarketTicker리스트를 획득합니다.
     func requestTickers() -> AnyPublisher<[Twenty4HourTickerForSymbolVO], Never>

--- a/Projects/Domain/Interface/UseCase/CoinDetailPageUseCase.swift
+++ b/Projects/Domain/Interface/UseCase/CoinDetailPageUseCase.swift
@@ -11,6 +11,7 @@ public protocol CoinDetailPageUseCase {
     func connectToOrderbookStream(symbolPair: String)
     func connectToTickerChangesStream(symbolPair: String)
     func connectToRecentTradeStream(symbolPair: String)
+    func disconnectToStreams(symbolPair: String)
     
     func getWholeOrderbookTable(symbolPair: String) async throws -> OrderbookUpdateVO
     func getChangeInOrderbook(symbolPair: String) -> AsyncStream<OrderbookUpdateVO>

--- a/Projects/Domain/Testing/StubAllwaysConnectedWebSocketHelper.swift
+++ b/Projects/Domain/Testing/StubAllwaysConnectedWebSocketHelper.swift
@@ -15,8 +15,8 @@ class StubAllwaysConnectedWebSocketHelper: WebSocketManagementHelper {
     
     init() { }
     
-    func requestSubscribeToStream(streams: [String]) { }
-    func requestUnsubscribeToStream(streams: [String]) { }
+    func requestSubscribeToStream(streams: [String], mustDeliver: Bool) { }
+    func requestUnsubscribeToStream(streams: [String], mustDeliver: Bool) { }
     func requestDisconnection() { }
     func requestConnection(connectionType: ConnectionType) { }
 }

--- a/Projects/Features/AllMarketTicker/Feature/Sources/AllMarketTickerViewModel.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/AllMarketTickerViewModel.swift
@@ -34,7 +34,7 @@ enum AllMarketTickerViewAction {
     case sortSelectionButtonTapped(type: SortSelectionCellType)
     case coinRowIsTapped(id: String)
     case enterBackground
-    case getbackToForeground
+    case getBackToForeground
     
     // Side effect
     case tickerListFetched(list: [Twenty4HourTickerForSymbolVO])
@@ -173,7 +173,7 @@ final class AllMarketTickerViewModel: UDFObservableObject, AllMarketTickerViewMo
             return Publishers.MergeMany(actions).eraseToAnyPublisher()
         case .onDisappear, .enterBackground:
             allMarketTickersUseCase.disConnectToAllMarketTickerStream()
-        case .getbackToForeground:
+        case .getBackToForeground:
             allMarketTickersUseCase.connectToAllMarketTickerStream()
         case .tickerListFetched(let newList):
             self.tickerCellVO = newList

--- a/Projects/Features/AllMarketTicker/Feature/Sources/View/AllMarketTickerView.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/View/AllMarketTickerView.swift
@@ -43,7 +43,7 @@ struct AllMarketTickerView: View {
         .onDisappear { viewModel.action(.onDisappear) }
         .onChange(of: scenePhase) { oldValue, newValue in
             if oldValue == .background && (newValue == .active || newValue == .inactive) {
-                viewModel.action(.getbackToForeground)
+                viewModel.action(.getBackToForeground)
             } else if newValue == .background {
                 viewModel.action(.enterBackground)
             }

--- a/Projects/Features/AllMarketTicker/Feature/Sources/View/AllMarketTickerView.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/View/AllMarketTickerView.swift
@@ -11,7 +11,7 @@ import CommonUI
 import CoreUtil
 
 struct AllMarketTickerView: View {
-    
+    @Environment(\.scenePhase) var scenePhase
     @StateObject private var viewModel: AllMarketTickerViewModel
     
     
@@ -40,6 +40,14 @@ struct AllMarketTickerView: View {
             tickerListContent()
         }
         .onAppear { viewModel.action(.onAppear) }
+        .onDisappear { viewModel.action(.onDisappear) }
+        .onChange(of: scenePhase) { oldValue, newValue in
+            if oldValue == .background && (newValue == .active || newValue == .inactive) {
+                viewModel.action(.getbackToForeground)
+            } else if newValue == .background {
+                viewModel.action(.enterBackground)
+            }
+        }
     }
     
     @ViewBuilder

--- a/Projects/Features/AllMarketTicker/Feature/Sources/View/TickerCollection/TickerListCellView.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/View/TickerCollection/TickerListCellView.swift
@@ -20,7 +20,6 @@ struct TickerListCellView: View {
     }
     
     var body: some View {
-        
         GeometryReader { geo in
             
             VStack(spacing: 0) {
@@ -74,5 +73,6 @@ struct TickerListCellView: View {
                 Spacer(minLength: 0)
             }
         }
+        .background { Rectangle().foregroundStyle(.white) }
     }
 }

--- a/Projects/Features/AllMarketTicker/Testing/FakeAllMarketTickersUseCase.swift
+++ b/Projects/Features/AllMarketTicker/Testing/FakeAllMarketTickersUseCase.swift
@@ -17,13 +17,16 @@ class FakeAllMarketTickersUseCase: AllMarketTickersUseCase {
     
     init() { }
     
-    func prepareStream() {
-        
+    func connectToAllMarketTickerStream() {
         self.timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
             guard let self else { return }
             let fakeTickers = createFakeTickers()
             fakeTickerPublisher.send(fakeTickers)
         }
+    }
+    
+    func disConnectToAllMarketTickerStream() {
+        timer?.invalidate()
     }
     
     func requestTickers() -> AnyPublisher<[DomainInterface.Twenty4HourTickerForSymbolVO], Never> {

--- a/Projects/Features/AllMarketTicker/Testing/StubEmptyAllMarketTickerUseCase.swift
+++ b/Projects/Features/AllMarketTicker/Testing/StubEmptyAllMarketTickerUseCase.swift
@@ -14,7 +14,9 @@ class StubEmptyAllMarketTickerUseCase: AllMarketTickersUseCase {
     
     init() { }
     
-    func prepareStream() { }
+    func disConnectToAllMarketTickerStream() { }
+    
+    func connectToAllMarketTickerStream() { }
     
     func requestTickers() -> AnyPublisher<[DomainInterface.Twenty4HourTickerForSymbolVO], Never> {
         

--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
@@ -107,7 +107,6 @@ final class CoinDetailPageViewModel: UDFObservableObject, CoinDetailPageViewMode
                 transform(bigestQuantity: bigestQuantity, orderbook: $0, type: .ask)
             }
         case .updateTickerInfo(let entity):
-            
             let (changePercentText, changeType) = createChangePercentTextConfig(percent: entity.changedPercent)
             newState.priceChagePercentInfo = .init(
                 changeType: changeType,
@@ -119,7 +118,6 @@ final class CoinDetailPageViewModel: UDFObservableObject, CoinDetailPageViewMode
                     bestBidPriceText: entity.bestBidPrice.roundDecimalPlaces(exact: 4),
                     bestAskPriceText: entity.bestAskPrice.roundDecimalPlaces(exact: 4)
                 )
-            
         case .updateTrades(let trades):
             newState.trades = trades.map(convertToRO)
         default:

--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
@@ -69,6 +69,9 @@ final class CoinDetailPageViewModel: UDFObservableObject, CoinDetailPageViewMode
         createStateStream()
     }
     
+    deinit {
+        print("asd")
+    }
     
     func mutate(_ action: CoinDetailPageAction) -> AnyPublisher<CoinDetailPageAction, Never> {
         switch action {
@@ -81,6 +84,10 @@ final class CoinDetailPageViewModel: UDFObservableObject, CoinDetailPageViewMode
             }
             return Just(action).eraseToAnyPublisher()
         case .exitButtonTapped:
+            // 연결 스트림 종료
+            useCase.disconnectToStreams(symbolPair: symbolPair)
+            
+            // 페이지 닫기
             listener?.request(.closePage)
         default:
             break

--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
@@ -27,7 +27,7 @@ enum CoinDetailPageAction {
     case onAppear
     case exitButtonTapped
     case enterBackground
-    case getbackToForeground
+    case getBackToForeground
     
     case updateOrderbook(bids: [Orderbook], asks: [Orderbook])
     case updateTickerInfo(entity: Twenty4HourTickerForSymbolVO)
@@ -94,7 +94,7 @@ final class CoinDetailPageViewModel: UDFObservableObject, CoinDetailPageViewMode
             
             // 페이지 닫기
             listener?.request(.closePage)
-        case .getbackToForeground:
+        case .getBackToForeground:
             // 오더북 스트림만 상태 초기화 및 재구독
             listenToOrderbookStream()
             

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
@@ -32,7 +32,7 @@ struct CoinDetailPageView: View {
         .onAppear { viewModel.action.send(.onAppear) }
         .onChange(of: scenePhase) { oldValue, newValue in
             if oldValue == .background && (newValue == .active || newValue == .inactive) {
-                viewModel.action.send(.getbackToForeground)
+                viewModel.action.send(.getBackToForeground)
             } else if newValue == .background {
                 viewModel.action.send(.enterBackground)
             }

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CoinDetailPageView: View {
-    
+    @Environment(\.scenePhase) var scenePhase
     @StateObject var viewModel: CoinDetailPageViewModel
     
     init(viewModel: CoinDetailPageViewModel) {
@@ -30,6 +30,11 @@ struct CoinDetailPageView: View {
             }
         }
         .onAppear { viewModel.action.send(.onAppear) }
+        .onChange(of: scenePhase) { oldValue, newValue in
+            if oldValue == .background && (newValue == .active || newValue == .inactive) {
+                viewModel.action.send(.getbackToForeground)
+            }
+        }
     }
     
     @ViewBuilder

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/CoinDetailPageView.swift
@@ -33,6 +33,8 @@ struct CoinDetailPageView: View {
         .onChange(of: scenePhase) { oldValue, newValue in
             if oldValue == .background && (newValue == .active || newValue == .inactive) {
                 viewModel.action.send(.getbackToForeground)
+            } else if newValue == .background {
+                viewModel.action.send(.enterBackground)
             }
         }
     }

--- a/Projects/Features/Root/Testing/StubWebSocketHelper.swift
+++ b/Projects/Features/Root/Testing/StubWebSocketHelper.swift
@@ -17,11 +17,11 @@ public class StubWebSocketHelper: WebSocketManagementHelper {
     
     public var isWebSocketConnected: AnyPublisher<Bool, Never> = Just(false).eraseToAnyPublisher()
     
-    public func requestSubscribeToStream(streams: [String]) {
+    public func requestSubscribeToStream(streams: [String], mustDeliver: Bool) {
         
     }
     
-    public func requestUnsubscribeToStream(streams: [String]) {
+    public func requestUnsubscribeToStream(streams: [String], mustDeliver: Bool) {
         
     }
     

--- a/Projects/Shared/WebSocketManagementHelper/Sources/Implements/DefaultWebSocketManagementHelper.swift
+++ b/Projects/Shared/WebSocketManagementHelper/Sources/Implements/DefaultWebSocketManagementHelper.swift
@@ -39,11 +39,11 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
     }
     
     
-    public func requestSubscribeToStream(streams: [Stream]) {
+    public func requestSubscribeToStream(streams: [Stream], mustDeliver: Bool) {
         subscribedStreamManageQueue.async { [weak self] in
             guard let self else { return }
             // 스트림 구독 메세지 전송
-            webSocketService.subscribeTo(message: streams) { [weak self] result in
+            webSocketService.subscribeTo(message: streams, mustDeliver: mustDeliver) { [weak self] result in
                 guard let self else { return }
                 switch result {
                 case .success:
@@ -72,7 +72,7 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
                             titleKey: TextKey.Alert.ActionTitle.retry.rawValue,
                             action: { [weak self] in
                                 guard let self else { return }
-                                requestSubscribeToStream(streams: streams)
+                                requestSubscribeToStream(streams: streams, mustDeliver: mustDeliver)
                             })
                         )
                         alertShooter.shoot(alertModel)
@@ -87,10 +87,10 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
     }
     
     
-    public func requestUnsubscribeToStream(streams willRemoveStreams: [Stream]) {
+    public func requestUnsubscribeToStream(streams willRemoveStreams: [Stream], mustDeliver: Bool) {
         
         // 특정스트림에 대해 구독을 해제 메세지 전송
-        webSocketService.unsubscribeTo(message: willRemoveStreams) { [weak self] result in
+        webSocketService.unsubscribeTo(message: willRemoveStreams, mustDeliver: mustDeliver) { [weak self] result in
                        
             guard let self else { return }
             
@@ -122,7 +122,7 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
                     titleKey: TextKey.Alert.ActionTitle.retry.rawValue
                 ) { [weak self] in
                     guard let self else { return }
-                    requestUnsubscribeToStream(streams: willRemoveStreams)
+                    requestUnsubscribeToStream(streams: willRemoveStreams, mustDeliver: mustDeliver)
                 })
                 alertShooter.shoot(alertModel)
             }
@@ -198,7 +198,7 @@ private extension DefaultWebSocketManagementHelper {
             guard let self else { return }
             printIfDebug("\(Self.self) 스트림 복구 실행 \(currentSubscribtions)")
             let recoveringStreamList = Array(currentSubscribtions)
-            requestSubscribeToStream(streams: recoveringStreamList)
+            requestSubscribeToStream(streams: recoveringStreamList, mustDeliver: true)
         }
     }
 }

--- a/Projects/Shared/WebSocketManagementHelper/Sources/Implements/DefaultWebSocketManagementHelper.swift
+++ b/Projects/Shared/WebSocketManagementHelper/Sources/Implements/DefaultWebSocketManagementHelper.swift
@@ -39,7 +39,7 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
     }
     
     
-    public func requestSubscribeToStream(streams: [Stream], autoReconnectionEnabled: Bool) {
+    public func requestSubscribeToStream(streams: [Stream]) {
         subscribedStreamManageQueue.async { [weak self] in
             guard let self else { return }
             // 스트림 구독 메세지 전송
@@ -51,7 +51,7 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
                         printIfDebug("\(Self.self): ✅\(stream)구독 성공")
                     }
                     // 구독에 성공한 스트림들을 기록합니다.
-                    if autoReconnectionEnabled { add(streams: streams) }
+                    add(streams: streams)
                 case .failure(let webSocketError):
                     switch webSocketError {
                     case .messageTransferFailed(_):
@@ -72,7 +72,7 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
                             titleKey: TextKey.Alert.ActionTitle.retry.rawValue,
                             action: { [weak self] in
                                 guard let self else { return }
-                                requestSubscribeToStream(streams: streams, autoReconnectionEnabled: autoReconnectionEnabled)
+                                requestSubscribeToStream(streams: streams)
                             })
                         )
                         alertShooter.shoot(alertModel)
@@ -198,7 +198,7 @@ private extension DefaultWebSocketManagementHelper {
             guard let self else { return }
             printIfDebug("\(Self.self) 스트림 복구 실행 \(currentSubscribtions)")
             let recoveringStreamList = Array(currentSubscribtions)
-            requestSubscribeToStream(streams: recoveringStreamList, autoReconnectionEnabled: true)
+            requestSubscribeToStream(streams: recoveringStreamList)
         }
     }
 }

--- a/Projects/Shared/WebSocketManagementHelper/Sources/Implements/DefaultWebSocketManagementHelper.swift
+++ b/Projects/Shared/WebSocketManagementHelper/Sources/Implements/DefaultWebSocketManagementHelper.swift
@@ -103,9 +103,13 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
                 }
             }
             
-            if case .failure(let error) = result {
+            switch result {
+            case .success:
+                willRemoveStreams.forEach { stream in
+                    printIfDebug("\(Self.self): ☑️\(stream)구독 해제 성공")
+                }
+            case .failure(let error):
                 printIfDebug("\(Self.self): 스트림 구독 해제 메세지 전송 실패 \(error.localizedDescription)")
-                
                 var alertModel = AlertModel(
                     titleKey: TextKey.Alert.Title.webSocketError.rawValue,
                     messageKey: TextKey.Alert.Message.streamUnsubFailure.rawValue

--- a/Projects/Shared/WebSocketManagementHelper/Sources/Implements/DefaultWebSocketManagementHelper.swift
+++ b/Projects/Shared/WebSocketManagementHelper/Sources/Implements/DefaultWebSocketManagementHelper.swift
@@ -39,7 +39,7 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
     }
     
     
-    public func requestSubscribeToStream(streams: [Stream]) {
+    public func requestSubscribeToStream(streams: [Stream], autoReconnectionEnabled: Bool) {
         subscribedStreamManageQueue.async { [weak self] in
             guard let self else { return }
             // 스트림 구독 메세지 전송
@@ -51,7 +51,7 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
                         printIfDebug("\(Self.self): ✅\(stream)구독 성공")
                     }
                     // 구독에 성공한 스트림들을 기록합니다.
-                    add(streams: streams)
+                    if autoReconnectionEnabled { add(streams: streams) }
                 case .failure(let webSocketError):
                     switch webSocketError {
                     case .messageTransferFailed(_):
@@ -72,7 +72,7 @@ public class DefaultWebSocketManagementHelper: WebSocketManagementHelper, WebSoc
                             titleKey: TextKey.Alert.ActionTitle.retry.rawValue,
                             action: { [weak self] in
                                 guard let self else { return }
-                                requestSubscribeToStream(streams: streams)
+                                requestSubscribeToStream(streams: streams, autoReconnectionEnabled: autoReconnectionEnabled)
                             })
                         )
                         alertShooter.shoot(alertModel)
@@ -198,7 +198,7 @@ private extension DefaultWebSocketManagementHelper {
             guard let self else { return }
             printIfDebug("\(Self.self) 스트림 복구 실행 \(currentSubscribtions)")
             let recoveringStreamList = Array(currentSubscribtions)
-            self.requestSubscribeToStream(streams: recoveringStreamList)
+            requestSubscribeToStream(streams: recoveringStreamList, autoReconnectionEnabled: true)
         }
     }
 }

--- a/Projects/Shared/WebSocketManagementHelper/Sources/Interface/WebSocketManagementHelper.swift
+++ b/Projects/Shared/WebSocketManagementHelper/Sources/Interface/WebSocketManagementHelper.swift
@@ -5,7 +5,6 @@
 
 import Combine
 
-
 public protocol WebSocketManagementHelper {
     
     /// 웹소켓 연결 상태를 퍼블리싱 합니다.
@@ -13,7 +12,14 @@ public protocol WebSocketManagementHelper {
     
     
     /// 스트림 연결을 요청합니다.
-    func requestSubscribeToStream(streams: [String])
+    ///
+    /// 이 메서드는 서버와의 스트림 연결을 시작합니다.
+    /// `autoReconnectionEnabled`가 `true`로 설정된 경우,
+    /// 애플리케이션이 백그라운드 상태에서 포그라운드로 전환될 때
+    /// 스트림이 자동으로 재연결됩니다.
+    ///
+    /// - Parameter autoReconnectionEnabled: 앱이 포그라운드로 전환될 때 스트림을 자동으로 재연결할지 여부입니다.
+    func requestSubscribeToStream(streams: [String], autoReconnectionEnabled: Bool)
     
     
     /// 스트림 연결을 끊을 것을 요청합니다.

--- a/Projects/Shared/WebSocketManagementHelper/Sources/Interface/WebSocketManagementHelper.swift
+++ b/Projects/Shared/WebSocketManagementHelper/Sources/Interface/WebSocketManagementHelper.swift
@@ -12,14 +12,7 @@ public protocol WebSocketManagementHelper {
     
     
     /// 스트림 연결을 요청합니다.
-    ///
-    /// 이 메서드는 서버와의 스트림 연결을 시작합니다.
-    /// `autoReconnectionEnabled`가 `true`로 설정된 경우,
-    /// 애플리케이션이 백그라운드 상태에서 포그라운드로 전환될 때
-    /// 스트림이 자동으로 재연결됩니다.
-    ///
-    /// - Parameter autoReconnectionEnabled: 앱이 포그라운드로 전환될 때 스트림을 자동으로 재연결할지 여부입니다.
-    func requestSubscribeToStream(streams: [String], autoReconnectionEnabled: Bool)
+    func requestSubscribeToStream(streams: [String])
     
     
     /// 스트림 연결을 끊을 것을 요청합니다.

--- a/Projects/Shared/WebSocketManagementHelper/Sources/Interface/WebSocketManagementHelper.swift
+++ b/Projects/Shared/WebSocketManagementHelper/Sources/Interface/WebSocketManagementHelper.swift
@@ -12,11 +12,11 @@ public protocol WebSocketManagementHelper {
     
     
     /// 스트림 연결을 요청합니다.
-    func requestSubscribeToStream(streams: [String])
+    func requestSubscribeToStream(streams: [String], mustDeliver: Bool)
     
     
     /// 스트림 연결을 끊을 것을 요청합니다.
-    func requestUnsubscribeToStream(streams: [String])
+    func requestUnsubscribeToStream(streams: [String], mustDeliver: Bool)
     
     
     /// 소켓을 연결을 종료할 것을 요청합니다.

--- a/Projects/Shared/WebSocketManagementHelper/Testing/StubWebSocketService.swift
+++ b/Projects/Shared/WebSocketManagementHelper/Testing/StubWebSocketService.swift
@@ -31,11 +31,11 @@ class StubAllwaysSuccessWebSocketService: WebSocketService {
         fakeStatePublisher.send(.disconnected)
     }
     
-    func subscribeTo(message: [String], completion: @escaping WebsocketCompletion) {
+    func subscribeTo(message: [String], mustDeliver: Bool, completion: @escaping WebsocketCompletion) {
         completion(.success(()))
     }
     
-    func unsubscribeTo(message: [String], completion: @escaping WebsocketCompletion) {
+    func unsubscribeTo(message: [String], mustDeliver: Bool, completion: @escaping WebsocketCompletion) {
         completion(.success(()))
     }
 }
@@ -63,11 +63,11 @@ class StubAllwaysFailureWebSocketService: WebSocketService {
         fakeStatePublisher.send(.disconnected)
     }
     
-    func subscribeTo(message: [String], completion: @escaping WebsocketCompletion) {
+    func subscribeTo(message: [String], mustDeliver: Bool, completion: @escaping WebsocketCompletion) {
         completion(.failure(WebSocketError.messageTransferFailed(error: nil)))
     }
     
-    func unsubscribeTo(message: [String], completion: @escaping WebsocketCompletion) {
+    func unsubscribeTo(message: [String], mustDeliver: Bool, completion: @escaping WebsocketCompletion) {
         completion(.failure(WebSocketError.messageTransferFailed(error: nil)))
     }
 }

--- a/Projects/Shared/WebSocketManagementHelper/Tests/Tests.swift
+++ b/Projects/Shared/WebSocketManagementHelper/Tests/Tests.swift
@@ -28,7 +28,7 @@ struct WebSocketManagementHelperTests {
         
         // When
         let testStreams = ["test1", "test2", "test3", "test4"]
-        webSocketHelper.requestSubscribeToStream(streams: testStreams)
+        webSocketHelper.requestSubscribeToStream(streams: testStreams, mustDeliver: false)
         try? await Task.sleep(for: .seconds(3))
         
         
@@ -54,7 +54,7 @@ struct WebSocketManagementHelperTests {
         
         // When
         let testStreams = ["test1", "test2", "test3", "test4"]
-        webSocketHelper.requestSubscribeToStream(streams: testStreams)
+        webSocketHelper.requestSubscribeToStream(streams: testStreams, mustDeliver: false)
         try? await Task.sleep(for: .seconds(3))
         
         
@@ -75,7 +75,7 @@ struct WebSocketManagementHelperTests {
         )
         
         // When
-        webSocketHelper.requestUnsubscribeToStream(streams: ["Test"])
+        webSocketHelper.requestUnsubscribeToStream(streams: ["Test"], mustDeliver: false)
         try? await Task.sleep(for: .seconds(3))
         
         


### PR DESCRIPTION
## 변경된 점

- 웹소켓 스트림 연결관리 방식 변경
- 웹소켓 서비스 메세지 캐싱 전략 구현

### 웹소켓 스트림 연결관리 방식 변경

- 기존 방식
    웹소켓 컨트롤러가 현재 구독중인 스트림을 내부 상태로 저장하고 포그라운드 진입이 웹소켓 연결과 동시 스트림을 복구합니다.

해당 방식의 경우 화면 별로 필요로하는 연결 규칙이 다를 수 있음으로 부적절하다고 판단했습니다.

- 변경된 방식
   웹소켓 컨트롤러는 웹소켓의 연결 및 해제만 관리하며 스트림은 해당 스트림을 활용하는 화면별로 독자적으로 구독 상태를 관리하도록 변경했습니다.

### 웹소켓 서비스 메세지 캐싱 전략 구현

웹소켓이 끊어진 상태에서 전송 요청된 메세지의 경우 네트워크 상황에 종속적으로 수신이 취소됩니다.
이를 방지하기 위해 웹소켓이 끊어진 경우 메세지를 캐싱하는 전략을 추가했습니다.
아래와 같이 매세드 시그니처에 `mustDeliver`매배변수를 통해 해당 전략의 사용여부를 결정합니다.
```swift
func subscribeTo(message: [String], mustDeliver: Bool, completion: @escaping WebsocketCompletion)
```
캐싱된 메세지는 웹소켓이 연결된 직후 순차적으로 전송되도록 구현했습니다.


## 화면 전환 및 스트림 연결관리 시현 영상

메인화면 -> 디테일 화면
<img src="https://github.com/user-attachments/assets/bdd7f064-955b-4c52-96d7-8d6c9ab91c1d" width=700 />
