### PR TITLE
[CVW-041] AllMarketTicker화면 ViewModel코드 리팩토링 및 예시앱 정상화

### DIFF
--- a/Projects/Data/Repository/Sources/DefaultUserConfigurationRepository.swift
+++ b/Projects/Data/Repository/Sources/DefaultUserConfigurationRepository.swift
@@ -107,7 +107,7 @@ public class DefaultUserConfigurationRepository: UserConfigurationRepository {
     
     
     
-    public func setGrideType(type: GridType) {
+    public func setGridType(type: GridType) {
         let config: UserConfiguration = .gridType
         
         // 디스크 저장 

--- a/Projects/Domain/Interface/Repository/UserConfigurationRepository.swift
+++ b/Projects/Domain/Interface/Repository/UserConfigurationRepository.swift
@@ -25,5 +25,5 @@ public protocol UserConfigurationRepository {
     func getGridType() -> GridType
     
     /// 그리드 타입을 설정합니다.
-    func setGrideType(type: GridType)
+    func setGridType(type: GridType)
 }

--- a/Projects/Features/AllMarketTicker/Example/Sources/App.swift
+++ b/Projects/Features/AllMarketTicker/Example/Sources/App.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import Combine
 
-@testable import AllMarketTickerFeature
+import AllMarketTickerFeature
 
 import DomainInterface
 import CoreUtil
@@ -26,16 +26,15 @@ struct CoinViewerApp: App {
     var body: some Scene {
         
         WindowGroup {
-          
-            AllMarketTickerView(
-                viewModel: .init(
-                    useCase: DependencyInjector.shared.resolve(),
-                    i18NManager: DependencyInjector.shared.resolve(),
-                    alertShooter: DependencyInjector.shared.resolve(),
-                    webSocketHelper: DependencyInjector.shared.resolve()
-                )
-            )
-
+            AllMarketTickerBuilder()
+                .build(listener: FakeListener())
+                .view
         }
+    }
+}
+
+class FakeListener: AllMarketTickerPageListener {
+    func request(_ request: AllMarketTickerPageListenerRequest) {
+        
     }
 }

--- a/Projects/Features/AllMarketTicker/Example/Sources/DI/Assemblies.swift
+++ b/Projects/Features/AllMarketTicker/Example/Sources/DI/Assemblies.swift
@@ -7,12 +7,13 @@
 
 import Foundation
 
-@testable import AllMarketTickerFeatureTesting
+import AllMarketTickerFeatureTesting
 
 import DomainInterface
 
 import I18N
 import AlertShooter
+import WebSocketManagementHelper
 
 import Swinject
 
@@ -29,12 +30,14 @@ public class Assemblies: Assembly {
             MockAlertShooter()
         }
         .inObjectScope(.container)
-        
-        
-        // MARK: Repository
-        container.register(UserConfigurationRepository.self) { _ in
-            FakeUserConfigurationRepository()
+        container.register(WebSocketManagementHelper.self) { _ in
+            MockWebSocketManagementHelper()
         }
         .inObjectScope(.container)
+        
+        // MARK: Domain
+        container.register(AllMarketTickersUseCase.self) { _ in
+            FakeAllMarketTickerUseCase()
+        }
     }
 }

--- a/Projects/Features/AllMarketTicker/Feature/Sources/Model/RenderObject/SortSelectionCellRO.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/Model/RenderObject/SortSelectionCellRO.swift
@@ -7,21 +7,14 @@
 
 import Foundation
 
-enum SortSelectionCellState {
-    case neutral
-    case ascending
-    case descending
-}
-
-struct SortSelectionCellRO: Identifiable {
-    var id: SortSelectionCellType { type }
-    let type: SortSelectionCellType
-    var sortState: SortSelectionCellState
+struct SortSelectionCellRO {
+    let sortType: SortSelectionCellType
+    var sortDirection: TickerSortingDirection
     
     // View state
     var displayText: String = "Test"
     var displayImageName: String {
-        switch sortState {
+        switch sortDirection {
         case .neutral:
             "chevron.up.chevron.down"
         case .ascending:
@@ -33,8 +26,8 @@ struct SortSelectionCellRO: Identifiable {
     var isLoad: Bool { !displayText.isEmpty }
     
     
-    init(type: SortSelectionCellType, sortState: SortSelectionCellState) {
-        self.type = type
-        self.sortState = sortState
+    init(sortType: SortSelectionCellType, sortDirection: TickerSortingDirection) {
+        self.sortType = sortType
+        self.sortDirection = sortDirection
     }
 }

--- a/Projects/Features/AllMarketTicker/Feature/Sources/Model/SortSelectionCellType.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/Model/SortSelectionCellType.swift
@@ -6,43 +6,39 @@
 //
 
 enum SortSelectionCellType: String, Identifiable {
-    
     var id: String { self.rawValue }
-    
     case symbol
     case price
     case changeIn24h
     
-    enum ComparatorType {
-        case ascending, descending
+    static var orderedList: [Self] {
+        [.symbol, .price, .changeIn24h]
     }
     
-    func getSortComparator(type: ComparatorType) -> TickerSortComparator {
-        switch self {
-        case .symbol:
-            switch type {
-            case .ascending:
+    func getComparator(direction: TickerSortingDirection) -> TickerComparator {
+        switch direction {
+        case .neutral:
+            TickerNoneComparator()
+        case .ascending:
+            switch self {
+            case .symbol:
                 TickerSymbolAscendingComparator()
-            case .descending:
-                TickerSymbolDescendingComparator()
-            }
-        case .price:
-            switch type {
-            case .ascending:
+            case .price:
                 TickerPriceAscendingComparator()
-            case .descending:
-                TickerPriceDescendingComparator()
-            }
-        case .changeIn24h:
-            switch type {
-            case .ascending:
+            case .changeIn24h:
                 Ticker24hChangeAscendingComparator()
-            case .descending:
+            }
+        case .descending:
+            switch self {
+            case .symbol:
+                TickerSymbolDescendingComparator()
+            case .price:
+                TickerPriceDescendingComparator()
+            case .changeIn24h:
                 Ticker24hChangeDescendingComparator()
             }
         }
     }
-    
     
     var displayTextKey: String {
         switch self {

--- a/Projects/Features/AllMarketTicker/Feature/Sources/Model/TickerComparator/TickerComparator.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/Model/TickerComparator/TickerComparator.swift
@@ -7,7 +7,7 @@
 
 import DomainInterface
 
-protocol TickerSortComparator {
+protocol TickerComparator {
     var id: String { get }
     func compare(lhs: TickerCellRO, rhs: TickerCellRO) -> Bool
 }

--- a/Projects/Features/AllMarketTicker/Feature/Sources/Model/TickerComparator/TickerNoneComparator.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/Model/TickerComparator/TickerNoneComparator.swift
@@ -5,7 +5,7 @@
 //  Created by choijunios on 12/6/24.
 //
 
-struct TickerNoneComparator: TickerSortComparator {
+struct TickerNoneComparator: TickerComparator {
     let id: String = .init(describing: TickerNoneComparator.self)
     func compare(lhs: TickerCellRO, rhs: TickerCellRO) -> Bool { true }
 }

--- a/Projects/Features/AllMarketTicker/Feature/Sources/Model/TickerComparator/TickerSymbolComparators.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/Model/TickerComparator/TickerSymbolComparators.swift
@@ -9,14 +9,14 @@ import DomainInterface
 
 // MARK: Symbol
 
-struct TickerSymbolAscendingComparator: TickerSortComparator {
+struct TickerSymbolAscendingComparator: TickerComparator {
     let id: String = String(describing: TickerSymbolAscendingComparator.self)
     func compare(lhs: TickerCellRO, rhs: TickerCellRO) -> Bool {
         lhs.symbolPair < rhs.symbolPair
     }
 }
 
-struct TickerSymbolDescendingComparator: TickerSortComparator {
+struct TickerSymbolDescendingComparator: TickerComparator {
     let id: String = String(describing: TickerSymbolDescendingComparator.self)
     func compare(lhs: TickerCellRO, rhs: TickerCellRO) -> Bool {
         lhs.symbolPair > rhs.symbolPair
@@ -25,14 +25,14 @@ struct TickerSymbolDescendingComparator: TickerSortComparator {
 
 // MARK: Price
 
-struct TickerPriceAscendingComparator: TickerSortComparator {
+struct TickerPriceAscendingComparator: TickerComparator {
     let id: String = String(describing: TickerPriceAscendingComparator.self)
     func compare(lhs: TickerCellRO, rhs: TickerCellRO) -> Bool {
         lhs.price < rhs.price
     }
 }
 
-struct TickerPriceDescendingComparator: TickerSortComparator {
+struct TickerPriceDescendingComparator: TickerComparator {
     let id: String = String(describing: TickerPriceDescendingComparator.self)
     func compare(lhs: TickerCellRO, rhs: TickerCellRO) -> Bool {
         lhs.price > rhs.price
@@ -41,14 +41,14 @@ struct TickerPriceDescendingComparator: TickerSortComparator {
 
 // MARK: 24hChangePercent
 
-struct Ticker24hChangeAscendingComparator: TickerSortComparator {
+struct Ticker24hChangeAscendingComparator: TickerComparator {
     let id: String = String(describing: Ticker24hChangeAscendingComparator.self)
     func compare(lhs: TickerCellRO, rhs: TickerCellRO) -> Bool {
         lhs.changedPercent < rhs.changedPercent
     }
 }
 
-struct Ticker24hChangeDescendingComparator: TickerSortComparator {
+struct Ticker24hChangeDescendingComparator: TickerComparator {
     let id: String = String(describing: Ticker24hChangeDescendingComparator.self)
     func compare(lhs: TickerCellRO, rhs: TickerCellRO) -> Bool {
         

--- a/Projects/Features/AllMarketTicker/Feature/Sources/Model/TickerSortingDirection.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/Model/TickerSortingDirection.swift
@@ -1,0 +1,23 @@
+//
+//  TickerSortingDirection.swift
+//  AllMarketTickerModule
+//
+//  Created by choijunios on 4/24/25.
+//
+
+enum TickerSortingDirection {
+    case neutral
+    case ascending
+    case descending
+    
+    func nextDirectionOnTap() -> Self {
+        switch self {
+        case .neutral:
+            .descending
+        case .ascending:
+            .descending
+        case .descending:
+            .ascending
+        }
+    }
+}

--- a/Projects/Features/AllMarketTicker/Feature/Sources/View/AllMarketTickerView.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/View/AllMarketTickerView.swift
@@ -53,12 +53,12 @@ struct AllMarketTickerView: View {
     @ViewBuilder
     private func sortSelectionTabContent() -> some View {
         LazyVGrid(columns: sortSelectionViewColumn, spacing: 0) {
-            ForEach(viewModel.state.displayingSortSelectionCellROs) { ro in
+            ForEach(viewModel.state.sortSelectionCells, id: \.sortType) { ro in
                 TickerSortSelectorView(renderObject: ro)
-                    .onTapGesture {
-                        viewModel.action(.sortSelectionButtonTapped(type: ro.type))
-                    }
                     .frame(height: 45)
+                    .onTapGesture {
+                        viewModel.action(.sortSelectionButtonTapped(type: ro.sortType))
+                    }
                     .skeleton(presentOrigin: viewModel.state.isLoaded)
             }
         }
@@ -102,7 +102,7 @@ struct AllMarketTickerView: View {
                 case .list:
                     GeometryReader { geo in
                         VStack(spacing: 3) {
-                            ForEach(0..<20) { _ in
+                            ForEach(Array(0..<viewModel.state.tickerRowCount), id: \.self) { _ in
                                 SkeletonUI()
                                     .frame(width: geo.size.width, height: 45)
                             }
@@ -110,7 +110,7 @@ struct AllMarketTickerView: View {
                     }
                 case .twoByTwo:
                     LazyVGrid(columns: tickerGridColumns, spacing: 10) {
-                        ForEach(0..<20) { _ in
+                        ForEach(Array(0..<viewModel.state.tickerRowCount), id: \.self) { _ in
                             SkeletonUI()
                                 .frame(height: 160)
                         }

--- a/Projects/Features/AllMarketTicker/Testing/FakeAllMarketTickerUseCase.swift
+++ b/Projects/Features/AllMarketTicker/Testing/FakeAllMarketTickerUseCase.swift
@@ -1,0 +1,58 @@
+//
+//  FakeAllMarketTickerUseCase.swift
+//  AllMarketTickerModule
+//
+//  Created by choijunios on 4/24/25.
+//
+
+import Combine
+
+import DomainInterface
+import CoreUtil
+
+public final class FakeAllMarketTickerUseCase: AllMarketTickersUseCase {
+    
+    public init() { }
+    
+    public func getTickerList(rowCount: UInt) -> AnyPublisher<[DomainInterface.Twenty4HourTickerForSymbolVO], Never> {
+        let list = (0..<rowCount).map { index in
+            var vo = Twenty4HourTickerForSymbolVO(
+                pairSymbol: "BTC\(index)"+"USDT",
+                price: CVNumber(Double(100 * index)),
+                totalTradedQuoteAssetVolume: CVNumber(Double(100 * index)),
+                changedPercent: CVNumber(Double(100 * index)),
+                bestBidPrice: CVNumber(Double(100 * index)),
+                bestAskPrice: CVNumber(Double(100 * index))
+            )
+            vo.setSymbols { pairSymbol in
+                ("BTC\(index)", "USDT")
+            }
+            return vo
+        }
+        let publisher = CurrentValueSubject<[Twenty4HourTickerForSymbolVO], Never>(list)
+        return publisher.eraseToAnyPublisher()
+    }
+    
+    public func getTickerList(rowCount: UInt) async -> [DomainInterface.Twenty4HourTickerForSymbolVO] {
+        (0..<rowCount).map { index in
+            var vo = Twenty4HourTickerForSymbolVO(
+                pairSymbol: "BTC\(index)"+"USDT",
+                price: CVNumber(Double(100 * index)),
+                totalTradedQuoteAssetVolume: CVNumber(Double(100 * index)),
+                changedPercent: CVNumber(Double(100 * index)),
+                bestBidPrice: CVNumber(Double(100 * index)),
+                bestAskPrice: CVNumber(Double(100 * index))
+            )
+            vo.setSymbols { pairSymbol in
+                ("BTC\(index)", "USDT")
+            }
+            return vo
+        }
+    }
+    
+    public func getExchangeRate(base: DomainInterface.CurrencyType, to: DomainInterface.CurrencyType) async -> Double? {
+        1.0
+    }
+    
+    public func getGridType() -> GridType { .list }
+}

--- a/Projects/Features/AllMarketTicker/Testing/FakeI18NManager.swift
+++ b/Projects/Features/AllMarketTicker/Testing/FakeI18NManager.swift
@@ -10,29 +10,31 @@ import Combine
 import I18N
 import DomainInterface
 
-class FakeI18NManager: I18NManager {
+public final class FakeI18NManager: I18NManager {
     
     let fakeUserConfigRepository = FakeUserConfigurationRepository()
     private let changePublisher: PassthroughSubject<I18NConfigMutation, Never> = .init()
+    
+    public init() { }
     
     public func getChangePublisher() -> AnyPublisher<I18NConfigMutation, Never> {
         changePublisher.eraseToAnyPublisher()
     }
     
-    func getCurrencyType() -> DomainInterface.CurrencyType {
+    public func getCurrencyType() -> DomainInterface.CurrencyType {
         fakeUserConfigRepository.getCurrencyType()
     }
     
-    func setCurrencyType(type: DomainInterface.CurrencyType) {
+    public func setCurrencyType(type: DomainInterface.CurrencyType) {
         fakeUserConfigRepository.setCurrencyType(type: type)
         changePublisher.send(.init(currencyType: type))
     }
     
-    func getLanguageType() -> DomainInterface.LanguageType {
+    public func getLanguageType() -> DomainInterface.LanguageType {
         fakeUserConfigRepository.getLanguageType()
     }
     
-    func setLanguageType(type: DomainInterface.LanguageType) {
+    public func setLanguageType(type: DomainInterface.LanguageType) {
         fakeUserConfigRepository.setLanguageType(type: type)
         changePublisher.send(.init(languageType: type))
     }

--- a/Projects/Features/AllMarketTicker/Testing/FakeUserConfigurationRepository.swift
+++ b/Projects/Features/AllMarketTicker/Testing/FakeUserConfigurationRepository.swift
@@ -7,7 +7,7 @@
 
 import DomainInterface
 
-class FakeUserConfigurationRepository: UserConfigurationRepository {
+public final class FakeUserConfigurationRepository: UserConfigurationRepository {
     
     private var fakeDB: [String: String] = [
         UserConfiguration.currency.savingKey: CurrencyType.dollar.savingValue,
@@ -15,30 +15,32 @@ class FakeUserConfigurationRepository: UserConfigurationRepository {
         UserConfiguration.gridType.savingKey: GridType.list.savingValue
     ]
     
-    func getCurrencyType() -> DomainInterface.CurrencyType {
+    public init() { }
+    
+    public func getCurrencyType() -> DomainInterface.CurrencyType {
         let value = fakeDB[UserConfiguration.currency.savingKey]!
         return .init(rawValue: value)!
     }
     
-    func setCurrencyType(type: DomainInterface.CurrencyType) {
+    public func setCurrencyType(type: DomainInterface.CurrencyType) {
         fakeDB[UserConfiguration.currency.savingKey] = type.savingValue
     }
     
-    func getLanguageType() -> DomainInterface.LanguageType {
+    public func getLanguageType() -> DomainInterface.LanguageType {
         let value = fakeDB[UserConfiguration.language.savingKey]!
         return .init(rawValue: value)!
     }
     
-    func setLanguageType(type: DomainInterface.LanguageType) {
+    public func setLanguageType(type: DomainInterface.LanguageType) {
         fakeDB[UserConfiguration.language.savingKey] = type.savingValue
     }
     
-    func getGridType() -> DomainInterface.GridType {
+    public func getGridType() -> DomainInterface.GridType {
         let value = fakeDB[UserConfiguration.gridType.savingKey]!
         return .init(rawValue: value)!
     }
     
-    func setGrideType(type: DomainInterface.GridType) {
+    public func setGrideType(type: DomainInterface.GridType) {
         fakeDB[UserConfiguration.gridType.savingKey] = type.savingValue
     }
 }

--- a/Projects/Features/AllMarketTicker/Testing/FakeUserConfigurationRepository.swift
+++ b/Projects/Features/AllMarketTicker/Testing/FakeUserConfigurationRepository.swift
@@ -40,7 +40,7 @@ public final class FakeUserConfigurationRepository: UserConfigurationRepository 
         return .init(rawValue: value)!
     }
     
-    public func setGrideType(type: DomainInterface.GridType) {
+    public func setGridType(type: DomainInterface.GridType) {
         fakeDB[UserConfiguration.gridType.savingKey] = type.savingValue
     }
 }

--- a/Projects/Features/AllMarketTicker/Testing/MockAlertShooter.swift
+++ b/Projects/Features/AllMarketTicker/Testing/MockAlertShooter.swift
@@ -7,6 +7,9 @@
 
 import AlertShooter
 
-class MockAlertShooter: AlertShooter {
-    override func shoot(_ model: AlertModel) { }
+public final class MockAlertShooter: AlertShooter {
+    
+    public override init() { }
+    
+    public override func shoot(_ model: AlertModel) { }
 }

--- a/Projects/Features/AllMarketTicker/Testing/MockWebSocketManagementHelper.swift
+++ b/Projects/Features/AllMarketTicker/Testing/MockWebSocketManagementHelper.swift
@@ -9,9 +9,12 @@ import Combine
 
 import WebSocketManagementHelper
 
-class MockWebSocketManagementHelper: WebSocketManagementHelper {
-    func requestSubscribeToStream(streams: [WebSocketStream], mustDeliver: Bool) { }
-    func requestUnsubscribeToStream(streams: [WebSocketStream], mustDeliver: Bool) { }
-    func requestDisconnection() { }
-    func requestConnection(connectionType: ConnectionType) { }
+public final class MockWebSocketManagementHelper: WebSocketManagementHelper {
+    
+    public init() { }
+    
+    public func requestSubscribeToStream(streams: [WebSocketStream], mustDeliver: Bool) { }
+    public func requestUnsubscribeToStream(streams: [WebSocketStream], mustDeliver: Bool) { }
+    public func requestDisconnection() { }
+    public func requestConnection(connectionType: ConnectionType) { }
 }

--- a/Projects/Features/Setting/Feature/Sources/ViewModel/SettingViewModel.swift
+++ b/Projects/Features/Setting/Feature/Sources/ViewModel/SettingViewModel.swift
@@ -95,7 +95,7 @@ class SettingViewModel: UDFObservableObject, SettingViewModelable {
                 newState.languageType = i18NManager.getLanguageType()
             case .gridType(let value):
                 let updatedValue: GridType = (value == .list) ? .twoByTwo : .list
-                userConfigurationRepository.setGrideType(type: updatedValue)
+                userConfigurationRepository.setGridType(type: updatedValue)
                 newState.gridType = updatedValue
             }
             newState.settingCellROs = createSettingCellROS(with: newState)


### PR DESCRIPTION
## 변경된 점

- AllMarketTicker화면 ViewModel코드 리팩토링 및 예시앱 정상화

### AllMarketTicker화면 ViewModel코드 리팩토링

기존코드의 경우 정렬 로직을 결정하는 부분이 복잡했습니다.
특히 `State`구조체에 View와는 무관한 상태가 있어 해당 부분을 제거하였습니다.

### 예시앱 정상화

`AllMarketTickerExampleApp`을 수정하여 `TestDoubles`객체들로 로직테스트가 가능하도록 설정했습니다.