### PR TITLE
[CVW-043] 모듈 의존성 생성 시점 연기

### DIFF
--- a/Projects/Features/AllMarketTicker/Feature/Sources/AllMarketTickerBuilder.swift
+++ b/Projects/Features/AllMarketTicker/Feature/Sources/AllMarketTickerBuilder.swift
@@ -16,21 +16,15 @@ import I18N
 import WebSocketManagementHelper
 
 public final class AllMarketTickerBuilder {
-    
-    // Service locator
-    @Injected private var allMarketTickersUseCase: AllMarketTickersUseCase
-    @Injected private var i18NManager: I18NManager
-    @Injected private var alertShooter: AlertShooter
-    @Injected private var webSocketManagementHelper: WebSocketManagementHelper
-    
+
     public init() { }
     
     public func build(listener: AllMarketTickerPageListener) -> AllMarketTickerRoutable {
         let viewModel = AllMarketTickerViewModel(
-            useCase: allMarketTickersUseCase,
-            i18NManager: i18NManager,
-            alertShooter: alertShooter,
-            webSocketHelper: webSocketManagementHelper
+            useCase: DependencyInjector.shared.resolve(),
+            i18NManager: DependencyInjector.shared.resolve(),
+            alertShooter: DependencyInjector.shared.resolve(),
+            webSocketHelper: DependencyInjector.shared.resolve()
         )
         viewModel.listener = listener
         let view = AllMarketTickerView(viewModel: viewModel)

--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageBuilder.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageBuilder.swift
@@ -10,17 +10,14 @@ import CoreUtil
 import WebSocketManagementHelper
 
 public final class CoinDetailPageBuilder {
-    // Dependency
-    @Injected private var coinDetailPageUseCase: CoinDetailPageUseCase
-    @Injected private var webSocketManagementHelper: WebSocketManagementHelper
     
     public init() { }
     
     public func build(listener: CoinDetailPageListener, symbolInfo: CoinSymbolInfo) -> CoinDetailPageRoutable {
         let viewModel = CoinDetailPageViewModel(
             symbolInfo: symbolInfo,
-            useCase: coinDetailPageUseCase,
-            webSocketManagementHelper: webSocketManagementHelper
+            useCase: DependencyInjector.shared.resolve(),
+            webSocketManagementHelper: DependencyInjector.shared.resolve()
         )
         viewModel.listener = listener
         let view = CoinDetailPageView(viewModel: viewModel)

--- a/Projects/Features/Root/Feature/Sources/TabBar/TabBarRouter.swift
+++ b/Projects/Features/Root/Feature/Sources/TabBar/TabBarRouter.swift
@@ -74,28 +74,44 @@ extension TabBarRouter {
     func tabBarPage(_ page: TabBarPage) -> AnyView {
         switch page {
         case .allMarketTicker:
-            let router = allMarketTickerBuilder.build(listener: viewModel)
-            if let allMarketTickerRouter { dettach(allMarketTickerRouter) }
-            allMarketTickerRouter = router
-            attach(router)
-            return router.view
+            getAllMarketTickerPageRouter().view
         case .setting:
-            let router = settingBuilder.build(listener: viewModel)
-            if let settingRouter { dettach(settingRouter) }
-            settingRouter = router
-            attach(router)
-            return router.view
+            getSettingPageRouter().view
         }
     }
     
     func view(_ destination: TabBarPageDestination) -> AnyView {
         switch destination {
         case .coinDetailPage(let listener, let symbolInfo):
-            let router = coinDetailPageBuilder.build(listener: listener, symbolInfo: symbolInfo)
-            if let coinDetailPageRouter { dettach(coinDetailPageRouter) }
-            coinDetailPageRouter = router
-            attach(router)
-            return router.view
+            getCoinDetailPageRouter(listener: listener, symbolInfo: symbolInfo).view
         }
+    }
+}
+
+
+// MARK: Create routers
+private extension TabBarRouter {
+    func getAllMarketTickerPageRouter() -> AllMarketTickerRoutable {
+        if let allMarketTickerRouter { return allMarketTickerRouter }
+        let router = allMarketTickerBuilder.build(listener: viewModel)
+        allMarketTickerRouter = router
+        attach(router)
+        return router
+    }
+    
+    func getSettingPageRouter() -> SettingRoutable {
+        if let settingRouter { return settingRouter }
+        let router = settingBuilder.build(listener: viewModel)
+        settingRouter = router
+        attach(router)
+        return router
+    }
+    
+    func getCoinDetailPageRouter(listener: CoinDetailPageListener, symbolInfo: CoinSymbolInfo) -> CoinDetailPageRoutable {
+        if let coinDetailPageRouter { return coinDetailPageRouter }
+        let router = coinDetailPageBuilder.build(listener: listener, symbolInfo: symbolInfo)
+        coinDetailPageRouter = router
+        attach(router)
+        return router
     }
 }

--- a/Projects/Features/Setting/Feature/Sources/SettingBuilder.swift
+++ b/Projects/Features/Setting/Feature/Sources/SettingBuilder.swift
@@ -10,16 +10,13 @@ import DomainInterface
 import CoreUtil
 
 public class SettingBuilder {
-    // Dependency
-    @Injected private var i18NManager: I18NManager
-    @Injected private var userConfigurationRepository: UserConfigurationRepository
     
     public init() { }
     
     public func build(listener: SettingPageListener) -> SettingRoutable {
         let viewModel = SettingViewModel(
-            i18NManager: i18NManager,
-            userConfigurationRepository: userConfigurationRepository
+            i18NManager: DependencyInjector.shared.resolve(),
+            userConfigurationRepository: DependencyInjector.shared.resolve()
         )
         viewModel.listener = listener
         let view = SettingView(viewModel: viewModel)


### PR DESCRIPTION
## 변경된 점

- 라우터 중복 생성 방지
- 모듈 의존성 생성 시점 연기

### 라우터 중복 생성 방지

뷰 리드로잉에 의해 View요청시 기존 구현은 빌더를 통해 새로운 Router를 생성하여 반환 했습니다.
비번한 리드로잉시 해당 방식은 문제를 야기할 수 있기에 생성된 라우터 인스턴스가 있어면 그것을 재활용하는 방법으로 개선했습니다.

### 모듈 의존성 생성 시점 연기

기존 구현의 경우 모듈의 빌더 인스턴스를 생성하는 시점에 모든 디팬던시를 `@Injected`프로퍼티를 통해 생성하였습니다.
실제 해당 모듈은 `build`함수 호출시 활용됨으로 생성시점과 사용시점이 어긋난다고 판단했습니다.
따라서 의존성 생성 시점을 `build`함수를 호출하는 시점으로 변경했습니다.