### PR TITLE
[CVW-000] Root, Tab Builder의존성 생성 시점 수정

### DIFF
--- a/Projects/Features/Root/Feature/Sources/RootBuilder.swift
+++ b/Projects/Features/Root/Feature/Sources/RootBuilder.swift
@@ -18,18 +18,13 @@ import AlertShooter
 import CoreUtil
 
 public final class RootBuilder {
-    // Dependency
-    @Injected private var rootPageUseCase: RootPageUseCase
-    @Injected private var alertShooter: AlertShooter
-    @Injected private var i18NManager: I18NManager
-
     public init() { }
     
     public func build() -> RootRoutable {
         let viewModel = RootViewModel(
-            useCase: rootPageUseCase,
-            alertShooter: alertShooter,
-            i18NManager: i18NManager
+            useCase: DependencyInjector.shared.resolve(),
+            alertShooter: DependencyInjector.shared.resolve(),
+            i18NManager: DependencyInjector.shared.resolve()
         )
         let view = RootView(viewModel: viewModel)
         let tabBarBuilder = TabBarBuilder()

--- a/Projects/Features/Root/Feature/Sources/TabBar/TabBarBuilder.swift
+++ b/Projects/Features/Root/Feature/Sources/TabBar/TabBarBuilder.swift
@@ -17,11 +17,10 @@ import I18N
 import CoreUtil
 
 class TabBarBuilder {
-    // Dependency
-    @Injected private var i18NManager: I18NManager
-    
     func build() -> TabBarRouter {
-        let viewModel = TabBarViewModel(i18NManager: i18NManager)
+        let viewModel = TabBarViewModel(
+            i18NManager: DependencyInjector.shared.resolve()
+        )
         let view = TabBarView(viewModel: viewModel)
         let allMarketTickerBuilder = AllMarketTickerBuilder()
         let settingBuilder = SettingBuilder()


### PR DESCRIPTION
## 변경된 점

- 모듈 의존성 생성 시점 연기 (#55 누락 모듈)

### 모듈 의존성 생성 시점 연기

기존 구현의 경우 모듈의 빌더 인스턴스를 생성하는 시점에 모든 디팬던시를 `@Injected`프로퍼티를 통해 생성하였습니다.
실제 해당 모듈은 `build`함수 호출시 활용됨으로 생성시점과 사용시점이 어긋난다고 판단했습니다.
따라서 의존성 생성 시점을 `build`함수를 호출하는 시점으로 변경했습니다.