### PR TITLE
[CVW-046] 코인 디테일 화면 QTY, 가겨정보 텍스트 표현 변경

### DIFF
--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
@@ -209,7 +209,7 @@ private extension CoinDetailPageViewModel {
     func transform(bigestQuantity: CVNumber, orderbook: Orderbook, type: OrderbookType) -> OrderbookCellRO {
         return OrderbookCellRO(
             type: type,
-            priceText: orderbook.price.roundDecimalPlaces(exact: 4),
+            priceText: orderbook.price.description,
             quantityText: orderbook.quantity.formatCompactNumberWithSuffix(),
             relativePercentOfQuantity: orderbook.quantity.double / bigestQuantity.double
         )
@@ -234,7 +234,7 @@ private extension CoinDetailPageViewModel {
         dateFormatter.dateFormat = "HH:mm:ss"
         let renderObject: CoinTradeRO = .init(
             id: entity.tradeId,
-            priceText: entity.price.roundDecimalPlaces(exact: 4),
+            priceText: entity.price.description,
             quantityText: entity.quantity.formatCompactNumberWithSuffix(),
             timeText: dateFormatter.string(from: entity.tradeTime),
             textColor: entity.tradeType == .buy ? .green : .red,

--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
@@ -127,12 +127,12 @@ final class CoinDetailPageViewModel: UDFObservableObject, CoinDetailPageViewMode
         var newState = state
         switch action {
         case .updateOrderbook(let bids, let asks):
-            guard let bigestQuantity = (bids + asks).map(\.quantity).max() else { break }
+            guard let biggestQuantity = (bids + asks).map(\.quantity).max() else { break }
             newState.bidOrderbooks = bids.map {
-                transform(bigestQuantity: bigestQuantity, orderbook: $0, type: .bid)
+                transform(biggestQuantity: biggestQuantity, orderbook: $0, type: .bid)
             }
             newState.askOrderbooks = asks.map {
-                transform(bigestQuantity: bigestQuantity, orderbook: $0, type: .ask)
+                transform(biggestQuantity: biggestQuantity, orderbook: $0, type: .ask)
             }
         case .updateTickerInfo(let entity):
             let (changePercentText, changeType) = createChangePercentTextConfig(percent: entity.changedPercent)
@@ -206,12 +206,12 @@ private extension CoinDetailPageViewModel {
             .subscribe(self.action)
     }
     
-    func transform(bigestQuantity: CVNumber, orderbook: Orderbook, type: OrderbookType) -> OrderbookCellRO {
+    func transform(biggestQuantity: CVNumber, orderbook: Orderbook, type: OrderbookType) -> OrderbookCellRO {
         return OrderbookCellRO(
             type: type,
             priceText: orderbook.price.description,
             quantityText: orderbook.quantity.formatCompactNumberWithSuffix(),
-            relativePercentOfQuantity: orderbook.quantity.double / bigestQuantity.double
+            relativePercentOfQuantity: orderbook.quantity.double / biggestQuantity.double
         )
     }
 }

--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
@@ -210,7 +210,7 @@ private extension CoinDetailPageViewModel {
         return OrderbookCellRO(
             type: type,
             priceText: orderbook.price.roundDecimalPlaces(exact: 4),
-            quantityText: orderbook.quantity.roundDecimalPlaces(exact: 4),
+            quantityText: orderbook.quantity.formatCompactNumberWithSuffix(),
             relativePercentOfQuantity: orderbook.quantity.double / bigestQuantity.double
         )
     }
@@ -235,7 +235,7 @@ private extension CoinDetailPageViewModel {
         let renderObject: CoinTradeRO = .init(
             id: entity.tradeId,
             priceText: entity.price.roundDecimalPlaces(exact: 4),
-            quantityText: entity.quantity.roundDecimalPlaces(exact: 4),
+            quantityText: entity.quantity.formatCompactNumberWithSuffix(),
             timeText: dateFormatter.string(from: entity.tradeTime),
             textColor: entity.tradeType == .buy ? .green : .red,
             backgroundEffectColor: (entity.tradeType == .buy ? .green : .red)
@@ -274,4 +274,3 @@ extension CoinDetailPageViewModel {
         }
     }
 }
-

--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
@@ -142,9 +142,9 @@ final class CoinDetailPageViewModel: UDFObservableObject, CoinDetailPageViewMode
             )
             newState.tickerInfo =
                 .init(
-                    currentPriceText: entity.price.roundDecimalPlaces(exact: 4),
-                    bestBidPriceText: entity.bestBidPrice.roundDecimalPlaces(exact: 4),
-                    bestAskPriceText: entity.bestAskPrice.roundDecimalPlaces(exact: 4)
+                    currentPriceText: entity.price.description,
+                    bestBidPriceText: entity.bestBidPrice.description,
+                    bestAskPriceText: entity.bestAskPrice.description
                 )
         case .updateTrades(let trades):
             newState.trades = trades.map(convertToRO)

--- a/Projects/Features/CoinDetail/Feature/Sources/Views/OrderbookCellView.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/Views/OrderbookCellView.swift
@@ -51,6 +51,8 @@ struct OrderbookCellView: View {
             case .priceFirst:
                 Text(renderObject.priceText)
                     .foregroundStyle(renderObject.priceTextColor)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
                 Spacer()
                 Text(renderObject.quantityText)
                     .foregroundStyle(.black)

--- a/Projects/Utils/CoreUtil/Project.swift
+++ b/Projects/Utils/CoreUtil/Project.swift
@@ -18,6 +18,18 @@ let project = Project(
                 D.ThirdParty.AdvancedSwift,
             ]
         ),
+        
+        // Tests
+        .target(
+            name: "CoreUtilTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "com.choijunios.feature.coreutil.tests",
+            sources: ["Tests/**"],
+            dependencies: [
+                .target(name: "CoreUtil"),
+            ]
+        ),
     ]
 )
 

--- a/Projects/Utils/CoreUtil/Sources/DataStructure/CVNumber.swift
+++ b/Projects/Utils/CoreUtil/Sources/DataStructure/CVNumber.swift
@@ -109,6 +109,7 @@ public extension CVNumber {
 
         for precision in (0...4).reversed() {
             let formatter = NumberFormatter()
+            formatter.roundingMode = .down
             formatter.maximumFractionDigits = precision
             let minFraction = unit.isEmpty ? 4 : 3
             if minFraction > precision {

--- a/Projects/Utils/CoreUtil/Sources/DataStructure/CVNumber.swift
+++ b/Projects/Utils/CoreUtil/Sources/DataStructure/CVNumber.swift
@@ -32,34 +32,12 @@ public struct CVNumber: Sendable, Hashable, Comparable, CustomStringConvertible,
         self.wrappedNumber = Decimal(value)
     }
     
-    public func roundToTwoDecimalPlaces() -> String {
-        
-        let formatter = NumberFormatter()
-        formatter.maximumFractionDigits = 2
-        formatter.minimumFractionDigits = 2
-        formatter.roundingMode = .down
-
-        let formattedString = formatter.string(from: wrappedNumber as NSDecimalNumber)
-        
-        return formattedString ?? "-1.0"
-    }
-    
-    public func roundDecimalPlaces(exact: Int) -> String {
-        
-        let formatter = NumberFormatter()
-        formatter.maximumFractionDigits = exact
-        formatter.minimumFractionDigits = exact
-        formatter.roundingMode = .down
-
-        let formattedString = formatter.string(from: wrappedNumber as NSDecimalNumber)
-        
-        return formattedString ?? "-1." + Array(repeating: "0", count: (exact-1))
-    }
-    
     public var description: String { wrappedNumber.description }
     public var double: Double { (wrappedNumber as NSDecimalNumber).doubleValue }
 }
 
+
+// MARK: Calc
 public extension CVNumber {
     static func + (lhs: Self, rhs: Self) -> Self {
         CVNumber(lhs.wrappedNumber + rhs.wrappedNumber)
@@ -71,5 +49,92 @@ public extension CVNumber {
     
     static func / (lhs: CVNumber, rhs: CVNumber) -> CVNumber {
         CVNumber(lhs.wrappedNumber / rhs.wrappedNumber)
+    }
+}
+
+
+// MARK: Rounded expression
+public extension CVNumber {
+    func roundToTwoDecimalPlaces() -> String {
+        
+        let formatter = NumberFormatter()
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        formatter.roundingMode = .down
+
+        let formattedString = formatter.string(from: wrappedNumber as NSDecimalNumber)
+        
+        return formattedString ?? "-1.0"
+    }
+    
+    func roundDecimalPlaces(exact: Int) -> String {
+        
+        let formatter = NumberFormatter()
+        formatter.maximumFractionDigits = exact
+        formatter.minimumFractionDigits = exact
+        formatter.roundingMode = .down
+
+        let formattedString = formatter.string(from: wrappedNumber as NSDecimalNumber)
+        
+        return formattedString ?? "-1." + Array(repeating: "0", count: (exact-1))
+    }
+}
+
+
+// MARK: Compact expression
+public extension CVNumber {
+    func formatCompactNumberWithSuffix() -> String {
+        let thousand = Decimal(1_000)
+        let million = Decimal(1_000_000)
+        let billion = Decimal(1_000_000_000)
+        let value = wrappedNumber
+        
+        var unit = ""
+        var base = value
+
+        switch value {
+        case billion...:
+            base = value / billion
+            unit = "B"
+        case million...:
+            base = value / million
+            unit = "M"
+        case thousand...:
+            base = value / thousand
+            unit = "K"
+        default:
+            base = value
+            unit = ""
+        }
+
+        for precision in (0...4).reversed() {
+            let formatter = NumberFormatter()
+            formatter.maximumFractionDigits = precision
+            let minFraction = unit.isEmpty ? 4 : 3
+            if minFraction > precision {
+                formatter.minimumFractionDigits = precision
+            } else {
+                formatter.minimumFractionDigits = minFraction
+            }
+            formatter.numberStyle = .decimal
+            
+            if unit.isEmpty {
+                // 1000미만 수인 경우
+                if let numString = formatter.string(from: base as NSNumber),
+                   numString.count <= 6 {
+                    return "\(numString)\(unit)"
+                }
+            } else {
+                if let numString = formatter.string(from: base as NSNumber),
+                   numString.count <= 5 {
+                    return "\(numString)\(unit)"
+                }
+            }
+        }
+
+        // 소수점 없애고 자른 뒤 리턴
+        let maxSize = unit.isEmpty ? 6 : 5
+        let slicedStr = "\(base.description.prefix(maxSize))"
+        return "\(slicedStr)\(unit)"
     }
 }

--- a/Projects/Utils/CoreUtil/Tests/CVNumberTests.swift
+++ b/Projects/Utils/CoreUtil/Tests/CVNumberTests.swift
@@ -1,0 +1,68 @@
+//
+//  CVNumberTests.swift
+//  CoreUtil
+//
+//  Created by choijunios on 5/12/25.
+//
+
+import Testing
+@testable import CoreUtil
+
+@Suite("CVNumber테스트")
+struct CVNumberTests {
+    @Test("K/M/B간소화 표현 테스트")
+    func checkCompactExpression() {
+        // Given
+        let numbers: [CVNumber] = [
+            CVNumber(0.0000001),
+            CVNumber(0.0001000),
+            
+            CVNumber(1.0),
+            CVNumber(10.0),
+            CVNumber(100.0),
+            
+            CVNumber(1_234.0),
+            CVNumber(12_345.0),
+            CVNumber(123_456.0),
+            
+            CVNumber(1_234_567.0),
+            CVNumber(12_345_678.0),
+            CVNumber(123_456_789.0),
+            
+            CVNumber(1_234_567_890.0),
+            CVNumber(12_345_678_900.0),
+            CVNumber(123_456_789_000.0),
+        ]
+        
+        
+        // When
+        let results = numbers.map({ $0.formatCompactNumberWithSuffix() })
+        
+        
+        // Then
+        let expectedResults: [String] = [
+            "0.0000",
+            "0.0001",
+            "1.0000",
+            "10.000",
+            "100.00",
+            
+            "1.234K",
+            "12.34K",
+            "123.4K",
+            
+            "1.234M",
+            "12.34M",
+            "123.4M",
+            
+            "1.234B",
+            "12.34B",
+            "123.4B",
+        ]
+        results.enumerated().forEach { index, str in
+            print(str, expectedResults[index], terminator: " ")
+            print("")
+            #expect(str == expectedResults[index])
+        }
+    }
+}


### PR DESCRIPTION
## 변경된 점

- 코인 디테일 화면 실시간 가격정보, 오더북, 최근거래정보 QTY, 가겨정보 텍스트 표현 변경
- CoreUtil테스트 모듈 생성

### 코인 디테일 화면 오더북, 최근거래정보 QTY, 가겨정보 텍스트 표현 변경

거래량에따라 텍스트 길이가 변해 정보확인에서 가시성이 떨어진다고 판단했습니다.

따라서 간소화 로직을 추가하여 표현의 가시성은 높이고 예상하지 못한 UI표현을 최소화 했습니다.

- 1000미만의 수 = 6자리로 표현 Ex) 0.000001 = 0.0000
- 1_000이상 = 1.000K
- 1_000_000이상 = 1.000M
- 1_000_000_000이상 = 1.000B

<table>
  <tr> 
    <td><b>변경전</b></td>
    <td><b>변경후</b></td>
  </tr>
  <tr> 
    <td><img src="https://github.com/user-attachments/assets/be3ead11-3276-4626-a2ac-20c5090c5c83" width=300 /></td>
    <td><img src="https://github.com/user-attachments/assets/a0c88408-b079-4080-bed7-f6de13f05f17" width=300 /></td>
  </tr>
</table>

### CoreUtil테스트 모듈 생성

수 간소화 로직은 `CoreUtil`모듈의 `CVNumber`의 인스턴스 매서드로 구현했습니다.
해당 로직의 경우 프로젝트 내 모든 영역에서 접근 가능함으로 테스트가 필수적이라고 판단했습니다.
따라서 테스트 모듈을 생성하고 확인이 필요한 케이스에 대한 검증을 진행했습니다.