### PR TITLE
[CVW-000] Fix, 가격표현 방식 수정

### DIFF
--- a/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
+++ b/Projects/Features/CoinDetail/Feature/Sources/CoinDetailPageViewModel.swift
@@ -281,8 +281,7 @@ final class CoinDetailPageViewModel: UDFObservableObject, CoinDetailPageViewMode
     
     
     private func createPriceText(info: ExchangeRateInfo, price: CVNumber, symbolPresentable: Bool = true) -> String {
-        let priceText = CVNumber(price.double * info.rate)
-            .adaptiveFractionFormat(min: 2, max: 8)
+        let priceText = CVNumber(price.double * info.rate).adaptiveToSize(10)
         if symbolPresentable {
             if info.currentType.isPrefix {
                 return "\(info.currentType.symbol) \(priceText)"

--- a/Projects/Utils/CoreUtil/Sources/DataStructure/CVNumber.swift
+++ b/Projects/Utils/CoreUtil/Sources/DataStructure/CVNumber.swift
@@ -139,22 +139,76 @@ public extension CVNumber {
         return "\(slicedStr)\(unit)"
     }
     
-    func adaptiveFractionFormat(min: Int, max: Int) -> String {
+    
+    func adaptiveToSize(_ size: Int) -> String {
+        
+        if NSDecimalNumber(decimal: wrappedNumber).intValue.description.count > size {
+            // 정수자리가 이미 최대길이를 초과한 경우
+            let thousand = Decimal(1_000)
+            let million = Decimal(1_000_000)
+            let billion = Decimal(1_000_000_000)
+            
+            var unit = ""
+            var value = wrappedNumber
+            
+            switch value {
+            case billion...:
+                value = value / billion
+                unit = "B"
+            case million...:
+                value = value / million
+                unit = "M"
+            case thousand...:
+                value = value / thousand
+                unit = "K"
+            default:
+                unit = ""
+            }
+            
+            let formatter = NumberFormatter()
+            formatter.roundingMode = .down
+            
+            var lastValidFraction = 0
+            for fraction in 0... {
+                formatter.minimumFractionDigits = fraction
+                if let numString = formatter.string(from: value as NSNumber) {
+                    if (numString.count + unit.count) < size {
+                        if numString.last != "0" { lastValidFraction = fraction }
+                        continue
+                    }
+                    else {
+                        formatter.minimumFractionDigits = lastValidFraction
+                        formatter.maximumFractionDigits = lastValidFraction
+                        if let numString = formatter.string(from: value as NSNumber) {
+                            return numString+unit
+                        }
+                    }
+                }
+            }
+            return value.description+unit
+        }
+    
+        let base = wrappedNumber
         let formatter = NumberFormatter()
         formatter.roundingMode = .down
-        formatter.minimumFractionDigits = min
         
-        let base = double
-        
-        for fraction in min...max {
-            formatter.maximumFractionDigits = fraction
+        var lastValidFraction = 0
+        for fraction in 0... {
+            formatter.minimumFractionDigits = fraction
             if let numString = formatter.string(from: base as NSNumber) {
-                if numString.last == "0" { continue }
+                if numString.count < size {
+                    if numString.last != "0" { lastValidFraction = fraction }
+                    continue
+                }
                 else {
-                    return numString
+                    formatter.minimumFractionDigits = lastValidFraction
+                    formatter.maximumFractionDigits = lastValidFraction
+                    if let numString = formatter.string(from: base as NSNumber) {
+                        return numString
+                    }
                 }
             }
         }
-        return roundDecimalPlaces(exact: max)
+        return base.description
     }
 }

--- a/Projects/Utils/CoreUtil/Sources/DataStructure/CVNumber.swift
+++ b/Projects/Utils/CoreUtil/Sources/DataStructure/CVNumber.swift
@@ -140,7 +140,7 @@ public extension CVNumber {
     }
     
     
-    func adaptiveToSize(_ size: Int) -> String {
+    func adaptiveToSize(_ size: Int, maxFractionDigits: Int = 15) -> String {
         
         if NSDecimalNumber(decimal: wrappedNumber).intValue.description.count > size {
             // 정수자리가 이미 최대길이를 초과한 경우
@@ -169,7 +169,7 @@ public extension CVNumber {
             formatter.roundingMode = .down
             
             var lastValidFraction = 0
-            for fraction in 0... {
+            for fraction in 0...maxFractionDigits {
                 formatter.minimumFractionDigits = fraction
                 if let numString = formatter.string(from: value as NSNumber) {
                     if (numString.count + unit.count) < size {
@@ -193,7 +193,7 @@ public extension CVNumber {
         formatter.roundingMode = .down
         
         var lastValidFraction = 0
-        for fraction in 0... {
+        for fraction in 0...maxFractionDigits {
             formatter.minimumFractionDigits = fraction
             if let numString = formatter.string(from: base as NSNumber) {
                 if numString.count < size {

--- a/Projects/Utils/CoreUtil/Tests/CVNumberTests.swift
+++ b/Projects/Utils/CoreUtil/Tests/CVNumberTests.swift
@@ -21,7 +21,6 @@ struct CVNumberTests {
         
         
         // Then
-        print(size, string)
         #expect(string.count <= size)
     }
     

--- a/Projects/Utils/CoreUtil/Tests/CVNumberTests.swift
+++ b/Projects/Utils/CoreUtil/Tests/CVNumberTests.swift
@@ -10,6 +10,44 @@ import Testing
 
 @Suite("CVNumber테스트")
 struct CVNumberTests {
+    @Test("길이 기반 축약표현, 최대 자리수 이하로 만들어지는지 확인", arguments: [1, 2, 3, 4, 5, 6])
+    func checkSizeCompaction(size: Int) {
+        // Given
+        let number = CVNumber(0.123456)
+        
+        
+        // When
+        let string = number.adaptiveToSize(size)
+        
+        
+        // Then
+        print(size, string)
+        #expect(string.count <= size)
+    }
+    
+    @Test("길이 기반 축약표현, K/M/B간소화 표현 테스트", arguments: [
+        (CVNumber(1200.0), "1K"),
+        (CVNumber(1230.0), "1K"),
+        (CVNumber(1234.0), "1K"),
+        (CVNumber(1234000.0), "1M"),
+        (CVNumber(1234000000.0), "1B"),
+    ])
+    func checkSizeCompactionKMB(_ input: (CVNumber, String)) {
+        // Given
+        let number = input.0
+        let size = 3
+        
+        
+        // When
+        let str = number.adaptiveToSize(size)
+        
+        
+        // Then
+        let result = input.1
+        #expect(str == result)
+    }
+    
+    
     @Test("K/M/B간소화 표현 테스트")
     func checkCompactExpression() {
         // Given
@@ -64,25 +102,5 @@ struct CVNumberTests {
             print("")
             #expect(str == expectedResults[index])
         }
-    }
-    
-    
-    @Test("적응형 소수점 표현 확인", arguments: [
-        CVNumber(0.1),
-        CVNumber(0.01),
-        CVNumber(0.001),
-        CVNumber(0.0001),
-    ])
-    func checkAdaptiveFractionFormat(number: CVNumber) {
-        // Given
-        let target = number
-        
-        
-        // When
-        let expression = target.adaptiveFractionFormat(min: 1, max: 4)
-        
-        
-        // Then
-        #expect(expression == target.description)
     }
 }


### PR DESCRIPTION
## 변경된 점

- 가격표현 방식 수정

### 가격표현 방식 수정

기존의 표현의 경우 Fraction자리수의 최대 최소를 지정하고, 자리수 0부터 최대 자리수까지 순회하면서 가장 첫번째로 유효한 값이 등장하면 즉시 순회를 뭠추는 방법을 선택했습니다.

해당 방식의 경우 소수점에 0만 등장하는 경우 1.000000 과 같이 무의미한 표현을 증가시켰고, 1.20323과 같은 값을 1.2로 변경해버려 정보 훼손이 다소 심하게 발생했습니다.

따라서 문자열의 길이를 지정하고 그에 따라 동적으로 소수점 및 unit을 통한 표현 방식을 적용하도록 수정했습니다.

현재 희망하는 문자열 길이를 10으로 설정했습니다.

<table>
<tr>
<td><b>변경 전(소수점 표현 부족)</b></td>
<td><b>변경 후</b></td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/b4745b53-6be3-4090-9315-10f72139532f" width=250 />
</td>
<td>
<img src="https://github.com/user-attachments/assets/6757ea49-776a-47d1-9558-7bb5781720c4" width=250 />
</td>
</tr>
<tr>
<td><b>변경 전(0반복)</b></td>
<td><b>변경 후</b></td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/c5cd94ae-5c44-4ccb-9576-6576c3c7f122" width=250 />
</td>
<td>
<img src="https://github.com/user-attachments/assets/65a7e19c-c5a0-43a2-9ba1-2108b32ed443" width=250 />
</td>
</tr>
</table>